### PR TITLE
fix/#44 debuging

### DIFF
--- a/src/main/java/com/aliens/friendship/config/security/CustomUserDetailService.java
+++ b/src/main/java/com/aliens/friendship/config/security/CustomUserDetailService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     @Cacheable(value = CacheKey.USER, key = "#username", unless = "#result == null")
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByNameWithAuthority(username).orElseThrow(() -> new NoSuchElementException("없는 회원입니다."));
+        Member member = memberRepository.findByUsernameWithAuthority(username).orElseThrow(() -> new NoSuchElementException("없는 회원입니다."));
         return CustomUserDetails.of(member);
     }
 }

--- a/src/main/java/com/aliens/friendship/domain/MatchingParticipant.java
+++ b/src/main/java/com/aliens/friendship/domain/MatchingParticipant.java
@@ -41,4 +41,8 @@ public class MatchingParticipant {
     @Column(name = COLUMN_GROUPID_NAME, nullable = false)
     private Integer groupId;
 
+    public void setIsMatched(Byte isMatched) {
+        this.isMatched = isMatched;
+    }
+
 }

--- a/src/main/java/com/aliens/friendship/domain/Member.java
+++ b/src/main/java/com/aliens/friendship/domain/Member.java
@@ -79,6 +79,10 @@ public class Member {
     @Builder.Default
     private Set<Authority> authorities = new HashSet<>();
 
+    public void setIsApplied(String status) {
+        this.isApplied = status;
+    }
+
     public static Member ofUser(JoinDto joinDto) {
         Member member = Member.builder()
                 .email(joinDto.getEmail())

--- a/src/main/java/com/aliens/friendship/service/MatchingService.java
+++ b/src/main/java/com/aliens/friendship/service/MatchingService.java
@@ -135,7 +135,7 @@ public class MatchingService {
                 ttl--;
             }
         }
-        updateStatus();
+        updateMatchingParticipantStatus();
 
         return matchedTeams;
     }
@@ -285,7 +285,7 @@ public class MatchingService {
     }
 
     // 매칭 완료 후 matching_participant status 변경
-    private void updateStatus() {
+    private void updateMatchingParticipantStatus() {
         for (int i = 0; i < matchingParticipants.size(); i++) {
             MatchingParticipant matchingParticipant = matchingParticipants.get(i);
             matchingParticipant.setIsMatched((byte) 1);


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #44 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 엔티티 클래스에서 신청, 매칭 상태 변경 메서드가 없어서 실행이 안되던 문제 해결

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 엔티티 클래스에 상태변경과 관련된 메서드를 사용하면, 데이터베이스에서 가져온 엔티티 정보를 수정하게 되므로, 무결성, 일관성이 지켜지지않는것 아닌가요? 반대로, 변경 메서드를 사용하지 않고, 서비스 코드에서, 상태 변경시 상태변경된 값을 제외한 나머지값이 동일한 객체를 만들고 이를 저장하는 메서드를 만들게 되면 setter는 사용하지 않게 되지만, 오버헤드가 커질것 같아 고민입니다.
아키텍처를 지키는 마음가짐이라면 후자가 맞겠죠?? 아니면 다른 방법이 있나요? 의견이 궁금합니다! @mjj111 @JeongeunChoi 

## ETC
fix의 경우 PR과정에서 develop에 바로 머지 하는게 어떨까요? 새로운 기능(feat) 처럼 고려해야할 부분이 많은 태그의 경우, 나누어서 한번에 합치는 게 맞겠다 싶어요. 하지만 지금과 같이, feat 브랜치 머지 후에 생기는 버그 해결 같은 경우 간단하며 충돌 문제도 없으므로 바로 develop에 적용하는것이 어떨까 싶습니다.