### PR TITLE
refactor/#38 엔티티 상태값에 enum 설정

### DIFF
--- a/src/main/java/com/aliens/friendship/emailAuthentication/domain/EmailAuthentication.java
+++ b/src/main/java/com/aliens/friendship/emailAuthentication/domain/EmailAuthentication.java
@@ -22,6 +22,7 @@ public class EmailAuthentication {
     public static final String COLUMN_EMAIL_NAME = "email";
     public static final String COLUMN_CREATEDTIME_NAME = "created_time";
 
+    public static final String COLUMN_STATUS_NAME = "status";
     @Id
     @Column(name = COLUMN_ID_NAME, nullable = false)
     private Integer id;
@@ -34,5 +35,8 @@ public class EmailAuthentication {
 
     @Column(name = COLUMN_CREATEDTIME_NAME, nullable = false)
     private Instant createdTime;
+
+    @Column(name = COLUMN_STATUS_NAME, nullable = false, length = 45)
+    private String status;
 
 }

--- a/src/main/java/com/aliens/friendship/emailAuthentication/domain/EmailAuthentication.java
+++ b/src/main/java/com/aliens/friendship/emailAuthentication/domain/EmailAuthentication.java
@@ -2,10 +2,7 @@ package com.aliens.friendship.emailAuthentication.domain;
 
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 import java.time.Instant;
 
 @Builder
@@ -36,7 +33,12 @@ public class EmailAuthentication {
     @Column(name = COLUMN_CREATEDTIME_NAME, nullable = false)
     private Instant createdTime;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = COLUMN_STATUS_NAME, nullable = false, length = 45)
-    private String status;
+    private Status status = Status.NOT_AUTHENTICATED;
+
+    public enum Status {
+        AUTHENTICATED, NOT_AUTHENTICATED;
+    }
 
 }

--- a/src/main/java/com/aliens/friendship/matching/domain/MatchingParticipant.java
+++ b/src/main/java/com/aliens/friendship/matching/domain/MatchingParticipant.java
@@ -36,14 +36,19 @@ public class MatchingParticipant {
     @JoinColumn(name = "preferred_language", nullable = false)
     private Language preferredLanguage;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = COLUMN_ISMATCHED_NAME, nullable = false)
-    private Byte isMatched;
+    private Status isMatched = Status.NOT_MATCHED;
 
     @Column(name = COLUMN_GROUPID_NAME, nullable = false)
     private Integer groupId;
 
-    public void setIsMatched(Byte isMatched) {
+    public void setIsMatched(Status isMatched) {
         this.isMatched = isMatched;
+    }
+
+    public enum Status {
+        MATCHED, NOT_MATCHED;
     }
 
 }

--- a/src/main/java/com/aliens/friendship/matching/service/MatchingService.java
+++ b/src/main/java/com/aliens/friendship/matching/service/MatchingService.java
@@ -88,9 +88,9 @@ public class MatchingService {
     }
 
     public void applyMatching(MatchingParticipantInfo applicantInfo) {
-        // 신청한 member의 is_applied를 waiting으로 변경
+        // 신청한 member의 is_applied를 APPLIED으로 변경
         Member member = memberRepository.findById(applicantInfo.getMemberId()).get();
-        member.setIsApplied("apply");
+        member.setIsApplied(Member.Status.APPLIED);
         System.out.println("applicantInfo = " + applicantInfo.getAnswer());
 
         // matching_applicant에 신청자 정보 저장
@@ -98,7 +98,7 @@ public class MatchingService {
                 .member(member)
                 .questionAnswer(applicantInfo.getAnswer())
                 .preferredLanguage(languageRepository.findById(applicantInfo.getLanguage()).get())
-                .isMatched((byte) 0)
+                .isMatched(MatchingParticipant.Status.NOT_MATCHED)
                 .groupId(-1)
                 .build();
 
@@ -110,14 +110,14 @@ public class MatchingService {
         // 해당 유저의 정보를 반환하는 코드 아직 구현 안되어 임시로 member 설정
         Member member = memberRepository.findById(10).get();
         System.out.println("member.getIsApplied() = " + member.getIsApplied());
-        if (member.getIsApplied().equals("apply")) {
-            if (matchingParticipantRepository.findById(10).get().getIsMatched() == 1) {
-                return "matched";
+        if (member.getIsApplied().equals(Member.Status.APPLIED)) {
+            if (matchingParticipantRepository.findById(10).get().getIsMatched() == MatchingParticipant.Status.MATCHED) {
+                return "MATCHED";
             } else {
-                return "waiting";
+                return "PENDING";
             }
         } else {
-            return "none";
+            return "NONE";
         }
     }
 
@@ -292,7 +292,7 @@ public class MatchingService {
     private void updateMatchingParticipantStatus() {
         for (int i = 0; i < matchingParticipants.size(); i++) {
             MatchingParticipant matchingParticipant = matchingParticipants.get(i);
-            matchingParticipant.setIsMatched((byte) 1);
+            matchingParticipant.setIsMatched((MatchingParticipant.Status.MATCHED));
             matchingParticipantRepository.save(matchingParticipant);
         }
     }

--- a/src/main/java/com/aliens/friendship/member/domain/Member.java
+++ b/src/main/java/com/aliens/friendship/member/domain/Member.java
@@ -70,16 +70,16 @@ public class Member {
     @Builder.Default
     private Byte notificationStatus = 0;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = COLUMN_ISAPPLIED_NAME, nullable = false, length = 45)
     @Builder.Default
-    private String isApplied = "none";
-
+    private Status isApplied = Status.NOT_APPLIED;
 
     @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
     @Builder.Default
     private Set<Authority> authorities = new HashSet<>();
 
-    public void setIsApplied(String status) {
+    public void setIsApplied(Status status) {
         this.isApplied = status;
     }
 
@@ -121,6 +121,10 @@ public class Member {
         return authorities.stream()
                 .map(Authority::getRole)
                 .collect(toList());
+    }
+
+    public enum Status {
+        APPLIED, NOT_APPLIED;
     }
 
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #38

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- MathcingParticipant.isMatched => MATCHED, NOT_MATCHED
- Member.isApplied => APPLIED, NOT_APPLIED
- Authentication.status ⇒ AUTHENTICATED, NOT_AUTHENTICATED
- 매칭상태반환 matched/waiting/none ⇒ MATCHED/PENDING/NOT_APPLIED(MatchingService 수정)
- ChattingRoom.status => PENDING, OPEN, CLOSE (기존에 설정되어있었음)