### PR TITLE
fix: MatchingService에서 enum사용하도록 수정

### DIFF
--- a/src/main/java/com/aliens/friendship/matching/service/MatchingService.java
+++ b/src/main/java/com/aliens/friendship/matching/service/MatchingService.java
@@ -90,7 +90,7 @@ public class MatchingService {
     public void applyMatching(MatchingParticipantInfo matchingParticipantInfo) {
         // 신청한 member의 is_applied를 waiting으로 변경
         Member member = memberRepository.findById(matchingParticipantInfo.getMemberId()).get();
-        member.setIsApplied("apply");
+        member.setIsApplied(Member.Status.APPLIED);
         System.out.println("applicantInfo = " + matchingParticipantInfo.getAnswer());
 
         // matching_applicant에 신청자 정보 저장
@@ -98,7 +98,7 @@ public class MatchingService {
                 .member(member)
                 .questionAnswer(matchingParticipantInfo.getAnswer())
                 .preferredLanguage(languageRepository.findById(matchingParticipantInfo.getLanguage()).get())
-                .isMatched((byte) 0)
+                .isMatched(MatchingParticipant.Status.NOT_MATCHED)
                 .groupId(-1)
                 .build();
 
@@ -339,7 +339,7 @@ public class MatchingService {
     // 매칭 완료 후 matching_participant status 변경
     private void updateMatchingParticipantStatus() {
         for (MatchingParticipant matchingParticipant : matchingParticipants) {
-            matchingParticipant.setIsMatched((byte) 1);
+            matchingParticipant.setIsMatched(MatchingParticipant.Status.MATCHED);
             matchingParticipantRepository.save(matchingParticipant);
         }
     }


### PR DESCRIPTION
resolves: #65

<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #65 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- MatchingService 상태값 변경 코드에 enum사용하도록 수정했습니다.
