### PR TITLE
feat/#74 birth and age 회원 정보에 만나이, 생년월일 추가

### DIFF
--- a/src/main/java/com/aliens/friendship/member/controller/APIController.java
+++ b/src/main/java/com/aliens/friendship/member/controller/APIController.java
@@ -48,7 +48,7 @@ public class APIController {
 
 
     @GetMapping("/members/{memberId}")
-    public MemberInfoDto getMemberInfo(@PathVariable int memberId) {
+    public MemberInfoDto getMemberInfo(@PathVariable int memberId) throws Exception {
         return memberService.getMemberInfo(memberId);
     }
 

--- a/src/main/java/com/aliens/friendship/member/controller/MemberController.java
+++ b/src/main/java/com/aliens/friendship/member/controller/MemberController.java
@@ -24,7 +24,7 @@ public class MemberController {
     }
 
     @GetMapping("/{email}")
-    public Response<MemberInfoDto> getMember(@PathVariable int memberId) {
+    public Response<MemberInfoDto> getMember(@PathVariable int memberId) throws Exception {
         return Response.SUCCESS(memberService.getMemberInfo(memberId));
     }
 

--- a/src/main/java/com/aliens/friendship/member/controller/dto/JoinDto.java
+++ b/src/main/java/com/aliens/friendship/member/controller/dto/JoinDto.java
@@ -13,7 +13,7 @@ public class JoinDto {
     private String mbti;
     private String gender;
     private Nationality nationality;
-    private Integer age;
+    private String birthday;
     private MultipartFile image;
     @Builder.Default
     private String imageUrl = "default.png";

--- a/src/main/java/com/aliens/friendship/member/controller/dto/MemberInfoDto.java
+++ b/src/main/java/com/aliens/friendship/member/controller/dto/MemberInfoDto.java
@@ -14,5 +14,6 @@ public class MemberInfoDto {
     private String gender;
     private int nationality;
     private int age;
+    private String birthday;
     private String name;
 }

--- a/src/main/java/com/aliens/friendship/member/domain/Member.java
+++ b/src/main/java/com/aliens/friendship/member/domain/Member.java
@@ -29,7 +29,7 @@ public class Member {
     public static final String COLUMN_PASSWORD_NAME = "password";
     public static final String COLUMN_MBTI_NAME = "mbti";
     public static final String COLUMN_GENDER_NAME = "gender";
-    public static final String COLUMN_AGE_NAME = "age";
+    public static final String COLUMN_BIRTHDAY_NAME = "birthday";
     public static final String COLUMN_NAME_NAME = "name";
     public static final String COLUMN_JOINDATE_NAME = "join_date";
     public static final String COLUMN_IMAGEURL_NAME = "image_url";
@@ -56,8 +56,8 @@ public class Member {
     @JoinColumn(name = "nationality", nullable = false)
     private Nationality nationality;
 
-    @Column(name = COLUMN_AGE_NAME, nullable = false)
-    private Integer age;
+    @Column(name = COLUMN_BIRTHDAY_NAME, nullable = false)
+    private String birthday;
 
     @Column(name = COLUMN_NAME_NAME, nullable = false, length = 45)
     private String name;
@@ -92,7 +92,7 @@ public class Member {
                 .password(joinDto.getPassword())
                 .mbti(joinDto.getMbti())
                 .gender(joinDto.getGender())
-                .age(joinDto.getAge())
+                .birthday(joinDto.getBirthday())
                 .name(joinDto.getName())
                 .nationality(joinDto.getNationality())
                 .joinDate(Instant.now())
@@ -108,7 +108,7 @@ public class Member {
                 .password(joinDto.getPassword())
                 .mbti(joinDto.getMbti())
                 .gender(joinDto.getGender())
-                .age(joinDto.getAge())
+                .birthday(joinDto.getBirthday())
                 .name(joinDto.getName())
                 .nationality(joinDto.getNationality())
                 .joinDate(Instant.now())

--- a/src/main/java/com/aliens/friendship/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/member/service/MemberService.java
@@ -90,10 +90,8 @@ public class MemberService {
                 jwtTokenUtil.generateRefreshToken(username), JwtExpirationEnums.REFRESH_TOKEN_EXPIRATION_TIME.getValue()));
     }
 
-    // 2
-    // TODO: 만나이 반환으로 수정
     @Transactional(readOnly = true)
-    public MemberInfoDto getMemberInfo(int memberId) {
+    public MemberInfoDto getMemberInfo(int memberId) throws Exception{
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
         return MemberInfoDto.builder()
                 .memberId(member.getId())
@@ -101,7 +99,8 @@ public class MemberService {
                 .mbti(member.getMbti())
                 .gender(member.getGender())
                 .nationality(member.getNationality().getId())
-                .age(member.getAge())
+                .birthday(member.getBirthday())
+                .age(getAgeFromBirthday(member.getBirthday()))
                 .name(member.getName())
                 .build();
     }

--- a/src/main/java/com/aliens/friendship/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/member/service/MemberService.java
@@ -3,18 +3,17 @@ package com.aliens.friendship.member.service;
 import com.aliens.friendship.global.config.cache.CacheKey;
 import com.aliens.friendship.global.config.jwt.JwtExpirationEnums;
 import com.aliens.friendship.jwt.domain.LogoutAccessToken;
+import com.aliens.friendship.jwt.domain.RefreshToken;
+import com.aliens.friendship.jwt.domain.dto.LoginDto;
+import com.aliens.friendship.jwt.domain.dto.TokenDto;
+import com.aliens.friendship.jwt.repository.LogoutAccessTokenRedisRepository;
+import com.aliens.friendship.jwt.repository.RefreshTokenRedisRepository;
+import com.aliens.friendship.jwt.util.JwtTokenUtil;
+import com.aliens.friendship.member.controller.dto.JoinDto;
 import com.aliens.friendship.member.controller.dto.MemberInfoDto;
 import com.aliens.friendship.member.controller.dto.WithdrawalDto;
 import com.aliens.friendship.member.domain.Member;
-import com.aliens.friendship.jwt.domain.RefreshToken;
-import com.aliens.friendship.member.controller.dto.JoinDto;
-import com.aliens.friendship.jwt.domain.dto.LoginDto;
-import com.aliens.friendship.jwt.domain.dto.MemberInfo;
-import com.aliens.friendship.jwt.domain.dto.TokenDto;
-import com.aliens.friendship.jwt.repository.LogoutAccessTokenRedisRepository;
 import com.aliens.friendship.member.repository.MemberRepository;
-import com.aliens.friendship.jwt.repository.RefreshTokenRedisRepository;
-import com.aliens.friendship.jwt.util.JwtTokenUtil;
 import com.aliens.friendship.member.repository.NationalityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -25,6 +24,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.NoSuchElementException;
 
 @Service
@@ -144,5 +147,26 @@ public class MemberService {
 
     private boolean lessThanReissueExpirationTimesLeft(String refreshToken) {
         return jwtTokenUtil.getRemainMilliSeconds(refreshToken) < JwtExpirationEnums.REISSUE_EXPIRATION_TIME.getValue();
+    }
+
+    private int getAgeFromBirthday(String birthday) throws Exception {
+        Calendar birthCalendar = getCalendarFromString(birthday);
+        Calendar today = Calendar.getInstance();
+
+        int age = today.get(Calendar.YEAR) - birthCalendar.get(Calendar.YEAR);
+        if (today.get(Calendar.DAY_OF_YEAR) < birthCalendar.get(Calendar.DAY_OF_YEAR)) {
+            age--;
+        }
+
+        return age;
+    }
+
+    private Calendar getCalendarFromString(String date) throws ParseException {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date birthDate = format.parse(date);
+        Calendar birthCalendar = Calendar.getInstance();
+        birthCalendar.setTime(birthDate);
+
+        return birthCalendar;
     }
 }

--- a/src/test/java/com/aliens/friendship/jwt/JwtAPITest.java
+++ b/src/test/java/com/aliens/friendship/jwt/JwtAPITest.java
@@ -1,9 +1,9 @@
 package com.aliens.friendship.jwt;
 
-import com.aliens.friendship.jwt.domain.dto.JoinDto;
 import com.aliens.friendship.jwt.domain.dto.LoginDto;
 import com.aliens.friendship.jwt.domain.dto.TokenDto;
 import com.aliens.friendship.jwt.util.JwtTokenUtil;
+import com.aliens.friendship.member.controller.dto.JoinDto;
 import com.aliens.friendship.member.domain.Nationality;
 import com.aliens.friendship.member.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,14 +43,14 @@ public class JwtAPITest {
 
     @BeforeEach
     @Transactional
-    public void setupMember() {
+    public void setupMember() throws Exception{
         Nationality nationality = Nationality.builder().id(1).natinalityText("korean").build();
         JoinDto memberJoinRequest = JoinDto.builder()
                 .password("1q2w3e4r")
                 .email("skatks1016@naver.com")
                 .name("김명준")
                 .mbti("INTJ")
-                .age(21)
+                .birthday("1998-01-01")
                 .gender("male")
                 .nationality(nationality)
                 .build();

--- a/src/test/java/com/aliens/friendship/jwt/JwtUtilTest.java
+++ b/src/test/java/com/aliens/friendship/jwt/JwtUtilTest.java
@@ -1,10 +1,10 @@
 package com.aliens.friendship.jwt;
 
 import com.aliens.friendship.global.config.security.CustomUserDetailService;
-import com.aliens.friendship.jwt.domain.dto.JoinDto;
 import com.aliens.friendship.jwt.domain.dto.LoginDto;
 import com.aliens.friendship.jwt.domain.dto.TokenDto;
 import com.aliens.friendship.jwt.util.JwtTokenUtil;
+import com.aliens.friendship.member.controller.dto.JoinDto;
 import com.aliens.friendship.member.domain.Nationality;
 import com.aliens.friendship.member.repository.MemberRepository;
 import com.aliens.friendship.member.service.MemberService;
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.multipart.MultipartFile;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,14 +38,14 @@ public class JwtUtilTest {
     JoinDto memberJoinRequest;
 
     @BeforeEach
-    public void setupMember() {
+    public void setupMember() throws Exception {
         Nationality nationality = Nationality.builder().id(1).natinalityText("korean").build();
         memberJoinRequest = JoinDto.builder()
                 .password("1q2w3e4r")
                 .email("skatks1016@naver.com")
                 .name("김명준")
                 .mbti("INTJ")
-                .age(21)
+                .birthday("1998-09-21")
                 .gender("male")
                 .nationality(nationality)
                 .build();

--- a/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
@@ -147,7 +147,7 @@ class MemberServiceTest {
     @Test
     @DisplayName("회원 정보 요청 성공")
     void GetMemberInfo_Success_When_GivenValidMember() throws Exception {
-    //given: 회원가입된 회원
+        //given: 회원가입된 회원
         JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");
         memberService.join(mockJoinDto);
         int memberId = memberRepository.findByEmail("test@case.com").get().getId();
@@ -155,6 +155,8 @@ class MemberServiceTest {
 
         //then: 회원 정보 요청 성공
         assertEquals("test@case.com", memberDto.getEmail());
+        assertEquals("1998-12-31", memberDto.getBirthday());
+        assertEquals(24, memberDto.getAge());
     }
 
     @Test
@@ -183,7 +185,7 @@ class MemberServiceTest {
                 .mbti("ENFJ")
                 .gender("MALE")
                 .nationality(new Nationality(1, "South Korea"))
-                .age(20)
+                .birthday("1998-12-31")
                 .image(mockMultipartFile)
                 .build();
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #74 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 테스트 코드 수정
<img width="842" alt="image" src="https://user-images.githubusercontent.com/87576669/218307761-41efaa15-09f6-4a08-8c4f-314b8e4c8733.png">

- 엔티티 수정
- 만나이 계산 메서드 추가
- 회원정보 요청시 기존의 나이값 대신 계산된 만나이와 생년월일을 반환하도록 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 곧 PR 50개가 다가오네요🎉🎉
