### PR TITLE
test/#82 querydsl

### DIFF
--- a/src/main/java/com/aliens/friendship/chatting/domain/Chatting.java
+++ b/src/main/java/com/aliens/friendship/chatting/domain/Chatting.java
@@ -5,6 +5,8 @@ import lombok.*;
 
 import javax.persistence.*;
 
+import static javax.persistence.GenerationType.IDENTITY;
+
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -16,7 +18,7 @@ public class Chatting {
     public static final String TABLE_NAME = "chatting";
     public static final String COLUMN_ID_NAME = "chatting_id";
 
-    @Id
+    @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = COLUMN_ID_NAME, nullable = false)
     private Integer id;
 

--- a/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
@@ -61,11 +61,11 @@ class ChattingRepositoryImplTest {
         assertEquals(partnerId2, matchingParticipants.get(3).getId());
     }
 
-    List<Member> createMember(){
+    private List<Member> createMember() {
         List<Member> members = new ArrayList<>();
-        for(int i=0; i<4; i++){
+        for (int i = 0; i < 4; i++) {
             Member member = Member.builder()
-                    .email("member"+i+"@test.com")
+                    .email("member" + i + "@test.com")
                     .password("1234567")
                     .mbti("ISFJ")
                     .gender("FEMALE")
@@ -83,9 +83,9 @@ class ChattingRepositoryImplTest {
         return members;
     }
 
-    List<MatchingParticipant> createMatchingParticipant(List<Member> members){
+    private List<MatchingParticipant> createMatchingParticipant(List<Member> members) {
         List<MatchingParticipant> matchingParticipants = new ArrayList<>();
-        for(int i=0; i<4; i++){
+        for (int i = 0; i < 4; i++) {
             MatchingParticipant matchingParticipant = MatchingParticipant.builder()
                     .member(members.get(i))
                     .isMatched(MatchingParticipant.Status.MATCHED)
@@ -99,18 +99,18 @@ class ChattingRepositoryImplTest {
         return matchingParticipants;
     }
 
-    List<ChattingRoom> createChattingRoom(){
+    private List<ChattingRoom> createChattingRoom() {
         List<ChattingRoom> chattingRooms = new ArrayList<>();
-        for(int i=1; i<=2; i++){
+        for (int i = 1; i <= 2; i++) {
             chattingRooms.add(chattingRoomRepository.save(ChattingRoom.builder()
-                    .id(i*(-1))
+                    .id(i * (-1))
                     .status(ChattingRoom.RoomStatus.OPEN).build()));
         }
 
         return chattingRooms;
     }
 
-    void createChatting(List<ChattingRoom> chattingRooms, List<MatchingParticipant> matchingParticipants){
+    private void createChatting(List<ChattingRoom> chattingRooms, List<MatchingParticipant> matchingParticipants) {
         chattingRepository.save(Chatting.builder()
                 .chattingRoom(chattingRooms.get(0))
                 .matchingParticipant(matchingParticipants.get(0)).build());

--- a/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
@@ -1,0 +1,42 @@
+package com.aliens.friendship.chatting.repository;
+
+import com.aliens.friendship.chatting.domain.ChattingRoom;
+import com.aliens.friendship.matching.domain.MatchingParticipant;
+import com.aliens.friendship.matching.repository.MatchingParticipantRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ChattingRepositoryImplTest {
+
+    @Autowired
+    ChattingRepository chattingRepository;
+
+    @Autowired
+    private ChattingRoomRepository chattingRoomRepository;
+
+    @Autowired
+    private MatchingParticipantRepository matchingParticipantRepository;
+
+    // 현재 db 상황: 9번 채팅룸(멤버 13과 18), 10번 채팅룸(멤버 14와 23)
+    @Test
+    @DisplayName("특정 1:1 채팅방의 대화 상대방 id 반환 성공")
+    void GetPartnerId_When_GivenMatchingParticipantAndChattingRoom() {
+        //given: 매칭 신청자와 해당 매칭 신청자가 속해 있는 채팅룸
+        MatchingParticipant matchingParticipant = matchingParticipantRepository.findById(13).orElseThrow(() -> new NoSuchElementException("Can't find matchingParticipant " + 13));
+        ChattingRoom chattingRoom = chattingRoomRepository.findById(9).orElseThrow(() -> new NoSuchElementException("Can't find chattingRoom " + 9));
+
+        //when: 매칭 신청자가 입장하는 1: 1 채팅방의 대화 상대 id 반환
+        Integer partnerId = chattingRepository.findPartnerIdByMatchingParticipantAndChattingRoom(matchingParticipant, chattingRoom);
+
+        //then: 대화 상대 id 반환 성공
+        assertEquals(partnerId, 18);
+    }
+}

--- a/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/chatting/repository/ChattingRepositoryImplTest.java
@@ -1,19 +1,34 @@
 package com.aliens.friendship.chatting.repository;
 
+import com.aliens.friendship.chatting.domain.Chatting;
 import com.aliens.friendship.chatting.domain.ChattingRoom;
+import com.aliens.friendship.jwt.domain.Authority;
+import com.aliens.friendship.matching.domain.Language;
 import com.aliens.friendship.matching.domain.MatchingParticipant;
 import com.aliens.friendship.matching.repository.MatchingParticipantRepository;
+import com.aliens.friendship.member.domain.Member;
+import com.aliens.friendship.member.domain.Nationality;
+import com.aliens.friendship.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional
 class ChattingRepositoryImplTest {
 
     @Autowired
@@ -25,18 +40,88 @@ class ChattingRepositoryImplTest {
     @Autowired
     private MatchingParticipantRepository matchingParticipantRepository;
 
-    // 현재 db 상황: 9번 채팅룸(멤버 13과 18), 10번 채팅룸(멤버 14와 23)
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("특정 1:1 채팅방의 대화 상대방 id 반환 성공")
     void GetPartnerId_When_GivenMatchingParticipantAndChattingRoom() {
-        //given: 매칭 신청자와 해당 매칭 신청자가 속해 있는 채팅룸
-        MatchingParticipant matchingParticipant = matchingParticipantRepository.findById(13).orElseThrow(() -> new NoSuchElementException("Can't find matchingParticipant " + 13));
-        ChattingRoom chattingRoom = chattingRoomRepository.findById(9).orElseThrow(() -> new NoSuchElementException("Can't find chattingRoom " + 9));
+        // given: 신청자 4명(0, 1, 2, 3), 채팅룸[0](신청자[0], 신청자[1]), 채팅룸[1](신청자[2], 신청자[3])
+        List<Member> members = createMember();
+        List<MatchingParticipant> matchingParticipants = createMatchingParticipant(members);
+        List<ChattingRoom> chattingRooms = createChattingRoom();
+        createChatting(chattingRooms, matchingParticipants);
 
-        //when: 매칭 신청자가 입장하는 1: 1 채팅방의 대화 상대 id 반환
-        Integer partnerId = chattingRepository.findPartnerIdByMatchingParticipantAndChattingRoom(matchingParticipant, chattingRoom);
+        // when: 매칭 신청자가 입장하는 1: 1 채팅방의 대화 상대 id 반환
+        Integer partnerId1 = chattingRepository.findPartnerIdByMatchingParticipantAndChattingRoom(matchingParticipants.get(0), chattingRooms.get(0));
+        Integer partnerId2 = chattingRepository.findPartnerIdByMatchingParticipantAndChattingRoom(matchingParticipants.get(2), chattingRooms.get(1));
 
-        //then: 대화 상대 id 반환 성공
-        assertEquals(partnerId, 18);
+        // then: 대화 상대 id 반환 성공
+        assertEquals(partnerId1, matchingParticipants.get(1).getId());
+        assertEquals(partnerId2, matchingParticipants.get(3).getId());
+    }
+
+    List<Member> createMember(){
+        List<Member> members = new ArrayList<>();
+        for(int i=0; i<4; i++){
+            Member member = Member.builder()
+                    .email("member"+i+"@test.com")
+                    .password("1234567")
+                    .mbti("ISFJ")
+                    .gender("FEMALE")
+                    .birthday("2002-01-17")
+                    .name("최정은")
+                    .nationality(new Nationality(1, "South Korea"))
+                    .joinDate(Instant.now())
+                    .imageUrl("/testUrl")
+                    .build();
+            member.updateIsApplied(Member.Status.APPLIED);
+            memberRepository.save(member);
+            members.add(member);
+        }
+
+        return members;
+    }
+
+    List<MatchingParticipant> createMatchingParticipant(List<Member> members){
+        List<MatchingParticipant> matchingParticipants = new ArrayList<>();
+        for(int i=0; i<4; i++){
+            MatchingParticipant matchingParticipant = MatchingParticipant.builder()
+                    .member(members.get(i))
+                    .isMatched(MatchingParticipant.Status.MATCHED)
+                    .questionAnswer(1)
+                    .preferredLanguage(new Language(1, "Korean"))
+                    .build();
+            matchingParticipantRepository.save(matchingParticipant);
+            matchingParticipants.add(matchingParticipant);
+        }
+
+        return matchingParticipants;
+    }
+
+    List<ChattingRoom> createChattingRoom(){
+        List<ChattingRoom> chattingRooms = new ArrayList<>();
+        for(int i=1; i<=2; i++){
+            chattingRooms.add(chattingRoomRepository.save(ChattingRoom.builder()
+                    .id(i*(-1))
+                    .status(ChattingRoom.RoomStatus.OPEN).build()));
+        }
+
+        return chattingRooms;
+    }
+
+    void createChatting(List<ChattingRoom> chattingRooms, List<MatchingParticipant> matchingParticipants){
+        chattingRepository.save(Chatting.builder()
+                .chattingRoom(chattingRooms.get(0))
+                .matchingParticipant(matchingParticipants.get(0)).build());
+        chattingRepository.save(Chatting.builder()
+                .chattingRoom(chattingRooms.get(0))
+                .matchingParticipant(matchingParticipants.get(1)).build());
+        chattingRepository.save(Chatting.builder()
+                .chattingRoom(chattingRooms.get(1))
+                .matchingParticipant(matchingParticipants.get(2)).build());
+        chattingRepository.save(Chatting.builder()
+                .chattingRoom(chattingRooms.get(1))
+                .matchingParticipant(matchingParticipants.get(3)).build());
     }
 }

--- a/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
@@ -32,7 +32,7 @@ class MemberRepositoryImplTest {
     @Transactional
     @Test
     @DisplayName("이메일로 멤버와 권한 정보 함께 반환 성공")
-    void getMemberWithAuthority_Success_When_GivenEmail() throws Exception {
+    void GetMemberWithAuthority_Success_When_GivenEmail() throws Exception {
         //given: 회원 정보 생성 후 회원가입
         JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");
         memberService.join(mockJoinDto);

--- a/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
@@ -1,0 +1,76 @@
+package com.aliens.friendship.member.repository;
+
+import com.aliens.friendship.jwt.domain.Authority;
+import com.aliens.friendship.member.controller.dto.JoinDto;
+import com.aliens.friendship.member.domain.Member;
+import com.aliens.friendship.member.domain.Nationality;
+import com.aliens.friendship.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class MemberRepositoryImplTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Transactional
+    @Test
+    @DisplayName("이메일로 멤버와 권한 정보 함께 반환 성공")
+    void getMemberWithAuthority_Success_When_GivenEmail() throws Exception {
+        //given: 회원 정보 생성 후 회원가입
+        JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");
+        memberService.join(mockJoinDto);
+
+        //when: 이메일로 member와 authority 정보 함께 반환
+        Member member = memberRepository.findByUsernameWithAuthority("test@case.com").orElseThrow(() -> new NoSuchElementException("없는 회원입니다."));
+
+        //then
+        //member의 정보와 mockJoinDto의 정보 일치 확인
+        assertThat(member.toString()).contains(mockJoinDto.getEmail())
+                .contains(mockJoinDto.getPassword())
+                .contains(mockJoinDto.getMbti())
+                .contains(mockJoinDto.getNationality().toString())
+                .contains(mockJoinDto.getBirthday())
+                .contains(mockJoinDto.getName())
+                .contains(mockJoinDto.getImageUrl());
+        //member의 authorities 정보 확인
+        Set<Authority> memberAuthorities = member.getAuthorities();
+        assertEquals(memberAuthorities.size(), 1);
+        Iterator<Authority> it = memberAuthorities.iterator();
+        while (it.hasNext()) {
+            Authority authority = it.next();
+            assertEquals(authority.getMember().getEmail(), "test@case.com");
+            assertEquals(authority.getAuthority(), "ROLE_USER");
+        }
+    }
+
+    private JoinDto createMockJoinDto(String email, String password) {
+        MultipartFile mockMultipartFile = new MockMultipartFile("file", "test.jpg", "image/jpeg", "test data".getBytes());
+        return JoinDto.builder()
+                .email(email)
+                .password(password)
+                .name("Joy")
+                .mbti("ISFJ")
+                .gender("FEMALE")
+                .nationality(new Nationality(1, "South Korea"))
+                .birthday("1993-12-31")
+                .image(mockMultipartFile)
+                .build();
+    }
+}

--- a/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
@@ -5,8 +5,13 @@ import com.aliens.friendship.member.controller.dto.JoinDto;
 import com.aliens.friendship.member.domain.Member;
 import com.aliens.friendship.member.domain.Nationality;
 import com.aliens.friendship.member.service.MemberService;
+import com.aliens.friendship.member.service.ProfileImageService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
@@ -15,27 +20,27 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@Transactional
 class MemberRepositoryImplTest {
-
-    @Autowired
-    private MemberService memberService;
 
     @Autowired
     private MemberRepository memberRepository;
 
-    @Transactional
     @Test
     @DisplayName("이메일로 멤버와 권한 정보 함께 반환 성공")
     void GetMemberWithAuthority_Success_When_GivenEmail() throws Exception {
-        //given: 회원 정보 생성 후 회원가입
+        //given: 회원 정보 생성 후 저장
         JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");
-        memberService.join(mockJoinDto);
+        memberRepository.save(Member.ofUser(mockJoinDto));
 
         //when: 이메일로 member와 authority 정보 함께 반환
         Member member = memberRepository.findByUsernameWithAuthority("test@case.com").orElseThrow(() -> new NoSuchElementException("없는 회원입니다."));


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #82 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
-  ChattingRepositoryImpl에 구현된 findPartnerIdByMatchingParticipantAndChattingRoom 함수 테스트
   - 1:1 채팅방의 대화 상대 id를 반환하는 함수 테스트 코드 작성
   - 임의로 db에 넣어서 QueryDsl이 정상 작동하는지만 확인해보았습니다!
     - 현재 db 상황
     -  9번 채팅룸: 멤버 13과 18
     - 10번 채팅룸: 멤버 14와 23

![image](https://user-images.githubusercontent.com/77786996/218931870-65439801-2e45-4824-83ef-2ac3f3a9faed.png)

- MemberRepsitoryImpl에 구현된 findByUsernameWithAuthority 함수 테스트
  - 이메일로 멤버와 권한을 함께 가져오는 함수 테스트 코드 작성

![image](https://user-images.githubusercontent.com/77786996/218931966-6743a15f-453f-4440-9a8e-25c25ef9c2c3.png)

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
