### PR TITLE
feat/BACKEND-37 프로필 이미지가 없이 회원가입이 가능하도록 수정

### DIFF
--- a/src/main/java/com/aliens/friendship/member/service/ProfileImageService.java
+++ b/src/main/java/com/aliens/friendship/member/service/ProfileImageService.java
@@ -14,7 +14,12 @@ public class ProfileImageService {
     //todo: 파일 기본 경로 properties로 설정
     private static final String DEFAULT_FILE_PATH = "/files/";
 
+    private static final String DEFAULT_PROFILE_IMAGE_PATH = "/files/default_profile_image.png";
+
     public String uploadProfileImage(MultipartFile uploadedFile) throws Exception {
+        if (uploadedFile == null || uploadedFile.isEmpty()) {
+            return DEFAULT_PROFILE_IMAGE_PATH;
+        }
         String fileName = getRandomFileName();
         uploadedFile.transferTo(new File(getUploadPath(fileName + "." + getImageExtension(uploadedFile.getOriginalFilename()))));
         return DEFAULT_FILE_PATH + fileName + "." + getImageExtension(uploadedFile.getOriginalFilename());

--- a/src/main/java/com/aliens/friendship/member/validation/ProfileImageValidator.java
+++ b/src/main/java/com/aliens/friendship/member/validation/ProfileImageValidator.java
@@ -19,16 +19,8 @@ public class ProfileImageValidator
             ConstraintValidatorContext context
     ) {
 
-        // 요청된 이미지 값이 Null 인지 체크
-        if (requestImage == null || requestImage.isEmpty()) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("회원 프로필 이미지는 필수 값입니다.")
-                    .addConstraintViolation();
-            return false;
-        }
-
         // 이미지 확장자 검증
-        if (!validateImageExtension(ImageUtil.getImageExtension(requestImage.getOriginalFilename()))) {
+        if (requestImage != null && !validateImageExtension(ImageUtil.getImageExtension(requestImage.getOriginalFilename()))) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("회원 프로필 이미지는 " + ALLOWED_IMAGE_EXTENSIONS + " 확장자만 가능합니다.")
                     .addConstraintViolation();
@@ -36,7 +28,7 @@ public class ProfileImageValidator
         }
 
         // 이미지 크기 검증
-        if (!validateImageSize(requestImage.getSize())) {
+        if (requestImage != null && !validateImageSize(requestImage.getSize())) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("회원 프로필 이미지는 10MB 이하여야 합니다.")
                     .addConstraintViolation();

--- a/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,7 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +28,6 @@ import static org.mockito.Mockito.*;
 import static org.springframework.http.HttpMethod.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -63,6 +60,24 @@ class MemberControllerTest {
         // when & then
         mockMvc.perform(multipart("/api/v1/member")
                         .file((MockMultipartFile) createMockImage())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(joinDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.response").value("회원가입 성공"));
+        verify(memberService, times(1)).join(any(JoinDto.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 프로필 이미지가 없는 경우")
+    void Join_Success_WithoutProfileImage() throws Exception {
+        // given
+        JoinDto joinDto = new JoinDto();
+        doNothing().when(memberService).join(joinDto);
+
+        // when & then
+        mockMvc.perform(multipart("/api/v1/member")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(joinDto)))
@@ -226,22 +241,6 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.response").value("프로필 이미지 수정 성공"));
         verify(memberService, times(1)).changeProfileImage(any(MultipartFile.class));
-    }
-
-    @DisplayName("프로필 이미지 검증 실페 - 이미지가 없을 경우")
-    @Test
-    void profileImage_validation_null() throws Exception {
-        // When & Then
-        mockMvc.perform(
-                        multipart(PUT, "/api/v1/member/profile-image")
-                                .contentType("multipart/form-data"))
-                .andExpect(status().is4xxClientError())
-                .andExpect(jsonPath("$.code").value("GB-C-001"))
-                .andExpect(jsonPath("$.message").value("유효하지 않은 요청 파라미터입니다."))
-                .andExpect(jsonPath("$.errors[0].field").value("profileImage"))
-                .andExpect(jsonPath("$.errors[0].value").value(""))
-                .andExpect(jsonPath("$.errors[0].reason").value("회원 프로필 이미지는 필수 값입니다."))
-                .andExpect(jsonPath("$.timestamp").isNotEmpty());
     }
 
     @DisplayName("프로필 이미지 검증 실패 - 유효하지 않은 크기의 이미지인 경우")

--- a/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
@@ -81,6 +81,36 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("회원가입 성공: 프로필 이미지가 없는 경우")
+    void CreateMember_Success_When_ProfileImageIsNull() throws Exception {
+        //given: 프로필 이미지가 없는 회원가입 정보
+        JoinDto mockJoinDto = JoinDto.builder()
+                        .email("test@case.com")
+                        .password("TestPassword")
+                        .name("Ryan")
+                        .mbti("ENFJ")
+                        .gender("MALE")
+                        .nationality(new Nationality(1, "South Korea"))
+                        .birthday("1998-12-31")
+                        .profileImage(null)
+                        .build();
+        String DEFAULT_PROFILE_IMAGE_PATH = "/files/default_profile_image.png";
+        EmailAuthentication mockEmailAuthentication = EmailAuthentication.createEmailAuthentication(mockJoinDto.getEmail());
+        mockEmailAuthentication.updateStatus(EmailAuthentication.Status.VERIFIED);
+        when(memberRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(Optional.empty());
+        when(emailAuthenticationRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(mockEmailAuthentication);
+        when(profileImageService.uploadProfileImage(mockJoinDto.getProfileImage())).thenReturn(DEFAULT_PROFILE_IMAGE_PATH);
+
+        //when: 회원가입
+        memberService.join(mockJoinDto);
+
+        //then: 회원가입 성공
+        verify(memberRepository, times(1)).save(any(Member.class));
+        verify(emailAuthenticationRepository, times(1)).findByEmail(anyString());
+        verify(profileImageService, times(1)).uploadProfileImage(null);
+    }
+
+    @Test
     @DisplayName("회원가입 예외: 이미 존재하는 이메일일 경우")
     void CreateMember_ThrowException_When_GivenExistEmail() throws Exception {
         //given: 이미 존재하는 이메일

--- a/src/test/java/com/aliens/friendship/member/service/ProfileImageServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/ProfileImageServiceTest.java
@@ -29,11 +29,25 @@ class ProfileImageServiceTest {
         // when: 파일 업로드
         String uploadedFilePath = profileImageService.uploadProfileImage(mockMultipartFile);
 
-        // then: 파일이 업로드 되었는지 확인R
+        // then: 파일이 업로드 되었는지 확인
         assertNotNull(uploadedFilePath);
         File uploadedFile = new File(System.getProperty("user.dir") + uploadedFilePath);
         assertTrue(uploadedFile.exists());
         uploadedFile.delete();
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 없는 경우")
+    public void UploadProfileImage_Success_WithoutProfileImage() throws Exception {
+        // given: 프로필 이미지가 없는 경우
+        MockMultipartFile mockMultipartFile = null;
+        String DEFAULT_PROFILE_IMAGE_PATH = "/files/default_profile_image.png";
+
+        // when: 파일 업로드
+        String uploadedFilePath = profileImageService.uploadProfileImage(mockMultipartFile);
+
+        // then: 기본 파일 경로를 반환하는지 확인
+        assertTrue(uploadedFilePath.equals(DEFAULT_PROFILE_IMAGE_PATH));
     }
 
     // Mock 회원 프로필 이미지 생성


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- BACKEND-37

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 프로필 이미지 validator 로직 수정
- 프로필 이미지가 없으면 업로드 메서드에서 기본 이미지 경로를 반환하도록 수정
- 테스트 케이스 작성

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- #119 과 같은 사유로 머지 브랜치를 우선 #116으로 두었습니다.
