### PR TITLE
hotfix: ProfileImageValidator 수정

### DIFF
--- a/src/main/java/com/aliens/friendship/domain/member/validation/ProfileImageValidator.java
+++ b/src/main/java/com/aliens/friendship/domain/member/validation/ProfileImageValidator.java
@@ -19,8 +19,11 @@ public class ProfileImageValidator
             ConstraintValidatorContext context
     ) {
 
+        // 이미지가 없는 경우 유효하다고 판단
+        if(requestImage == null || requestImage.isEmpty()) return true;
+
         // 이미지 확장자 검증
-        if (requestImage != null && !validateImageExtension(ImageUtil.getImageExtension(requestImage.getOriginalFilename()))) {
+        if (!validateImageExtension(ImageUtil.getImageExtension(requestImage.getOriginalFilename()))) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("회원 프로필 이미지는 " + ALLOWED_IMAGE_EXTENSIONS + " 확장자만 가능합니다.")
                     .addConstraintViolation();
@@ -28,7 +31,7 @@ public class ProfileImageValidator
         }
 
         // 이미지 크기 검증
-        if (requestImage != null && !validateImageSize(requestImage.getSize())) {
+        if (!validateImageSize(requestImage.getSize())) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate("회원 프로필 이미지는 10MB 이하여야 합니다.")
                     .addConstraintViolation();


### PR DESCRIPTION
- MultipartFile이 null인 경우 외에 Empty인 경우도 유효한 것으로 처리

<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- 프로필 이미지가 없는 경우 기본 이미지로 회원가입이 안되는 현상 발생
- profileImageValidator에서 이미지가 없는 경우를 인식하지 못하는 것을 확인

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 기존 multipartPartFile == null 로직 이외에 .isEmpty() 조건을 추가 검증하도록 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 파일 업로드가 안되던 이슈는 별개의 문제로 도커 컨테이너 내부에서 별도의 격리 파일 시스템을 사용해서 발생하는 것을 확인했습니다! 현재는 업로드 및 정상 회원가입 가능합니다!
