### PR TITLE
feat/Backend-51 회원 관련 정보 삭제 기능 추가

### DIFF
--- a/files/04bfbdc6-1bb7-44fb-8b51-7fc5997feda8_ProfileImage.jpg
+++ b/files/04bfbdc6-1bb7-44fb-8b51-7fc5997feda8_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/11db4b56-36f0-4f88-866c-850e65075b44_ProfileImage.jpg
+++ b/files/11db4b56-36f0-4f88-866c-850e65075b44_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/2ed93e15-75fe-4975-89bc-8bacf3701226_ProfileImage.jpg
+++ b/files/2ed93e15-75fe-4975-89bc-8bacf3701226_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/34129f10-cf63-4c85-9fd7-2e2f6423fc76_ProfileImage.jpg
+++ b/files/34129f10-cf63-4c85-9fd7-2e2f6423fc76_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/4832cd10-17af-4e00-8549-61cf6cf34954_ProfileImage.jpg
+++ b/files/4832cd10-17af-4e00-8549-61cf6cf34954_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/543fefd8-ef36-4efc-9f57-6d0dc1a623fa_ProfileImage.jpg
+++ b/files/543fefd8-ef36-4efc-9f57-6d0dc1a623fa_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/57552582-b3ec-49eb-9443-1b45c4bf32d9_ProfileImage.jpg
+++ b/files/57552582-b3ec-49eb-9443-1b45c4bf32d9_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/ccc1ccc5-bdd1-4feb-ad41-fe522bbb1c83_ProfileImage.jpg
+++ b/files/ccc1ccc5-bdd1-4feb-ad41-fe522bbb1c83_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/files/fcf9540a-6929-4cfe-9b35-825626034f09_ProfileImage.jpg
+++ b/files/fcf9540a-6929-4cfe-9b35-825626034f09_ProfileImage.jpg
@@ -1,1 +1,0 @@
-test data

--- a/src/main/java/com/aliens/friendship/domain/matching/domain/Applicant.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/domain/Applicant.java
@@ -26,7 +26,7 @@ public class Applicant {
     private Integer id;
 
     @MapsId
-    @OneToOne(fetch = FetchType.LAZY, optional = false, cascade = CascadeType.REMOVE)
+    @OneToOne(optional = false, cascade = CascadeType.REMOVE)
     @JoinColumn(name = COLUMN_ID_NAME, nullable = false)
     private Member member;
 

--- a/src/main/java/com/aliens/friendship/domain/matching/domain/BlockingInfo.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/domain/BlockingInfo.java
@@ -25,11 +25,11 @@ public class BlockingInfo {
     private Integer id;
 
     @ManyToOne( optional = false, cascade=CascadeType.REMOVE)
-    @JoinColumn(name = "blocked_member_id", nullable = false)
+    @JoinColumn(name = "blocked_member_id")
     private Member blockedMember;
 
     @ManyToOne( optional = false, cascade=CascadeType.REMOVE)
-    @JoinColumn(name = "blocking_member_id", nullable = false)
+    @JoinColumn(name = "blocking_member_id")
     private Member blockingMember;
 
 }

--- a/src/main/java/com/aliens/friendship/domain/matching/domain/Matching.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/domain/Matching.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import javax.persistence.*;
 
+import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.GenerationType.IDENTITY;
 
 @Builder
@@ -24,7 +25,7 @@ public class Matching {
     @Column(name = COLUMN_ID_NAME, nullable = false)
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(optional = false, cascade = CascadeType.REMOVE)
     @JoinColumn(name = COLUMN_APPLICANT_NAME, nullable = false)
     private Applicant applicant;
 

--- a/src/main/java/com/aliens/friendship/domain/matching/domain/Report.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/domain/Report.java
@@ -31,12 +31,12 @@ public class Report {
     private Integer id;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(optional = false, cascade = CascadeType.REMOVE)
     @JoinColumn(name = COLUMN_REPORTEDMEMBER_NAME, nullable = false)
     private Member reportedMember;
 
     @NotNull
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(optional = false, cascade = CascadeType.REMOVE)
     @JoinColumn(name = COLUMN_REPORTERMEMBER_NAME, nullable = false)
     private Member reporterMember;
 

--- a/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
@@ -143,4 +143,14 @@ public class MemberController {
                 status
         );
     }
+
+    // TODO: 관리자 권한 추가
+    @DeleteMapping("/{memberId}")
+    public CommonResult deleteMemberInfoByAdmin(@PathVariable Integer memberId){
+        memberService.deleteMemberInfoByAdmin(memberId);
+        return responseService.getSuccessResult(
+                OK.value(),
+                "회원 관련 정보 삭제에 성공하였습니다."
+        );
+    }
 }

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -83,6 +83,11 @@ public class MemberService {
         memberRepository.delete(member);
     }
 
+    public void deleteMemberInfoByAdmin(Integer memberId) {
+        memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        memberRepository.deleteById(memberId);
+    }
+
     public TokenDto login(LoginDto loginDto) throws Exception {
         Member member = memberRepository.findByEmail(loginDto.getEmail()).orElseThrow(MemberNotFoundException::new);
         checkWithdrawn(member.getStatus());

--- a/src/main/java/com/aliens/friendship/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/aliens/friendship/global/config/security/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .antMatchers("/ws-stomp/**","/send/**","/room/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/", "/join/**", "/login", "/api/v1/member/authentication", "/api/v1/member", "/api/v1/member/{email}/password/temp", "/api/v1/email/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/v1/member/email/{email}/existence", "/api/v1/member/{email}/authentication-status", "/api/v1/member/nationalities", "/api/v1/email/**").permitAll()
+                .antMatchers(HttpMethod.DELETE, "/api/v1/member/{memberId}").permitAll()
                 .antMatchers("/matching/**", "/health", "/logout").authenticated()
                 .anyRequest().hasRole("USER")
 

--- a/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
@@ -285,4 +285,17 @@ class MemberControllerTest {
         verify(memberService, times(1)).getMemberAuthenticationStatus(anyString());
     }
 
+    @Test
+    @DisplayName("멤버 관련 정보 삭제 성공")
+    void deleteMemberInfoByAdmin_Success() throws Exception {
+        // given
+        Integer memberId = 17;
+        doNothing().when(memberService).deleteMemberInfoByAdmin(memberId);
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/member/" + memberId))
+                .andExpect(status().isOk());
+        verify(memberService, times(1)).deleteMemberInfoByAdmin(anyInt());
+    }
+
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
-  Backend-51

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
-  특정 member와 관련된 모든 정보를 삭제해주는 기능을 추가
   - member와 관련된 모든 정보가 삭제됨.
   - applicant, matching, report, blocking_info
- 외래키 속성 중에  cascade 옵션 설정 변경
   - 모든 외래키의 On Delete가 RESTRICT로 설정되어있어 삭제가 이루어지지 않아, member와 관련된 외래키의 경우 CASCADE로 변경
![image](https://github.com/4Ailen/backend/assets/77786996/18a33e49-ec37-49ef-a16b-9c1420f8a54d)


- 추가된 코드에 따라 테스트 코드 작성

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 추후에 관리자 계정을 하나 만들어서, 관리자만 삭제 가능하도록 하는게 좋을 것 같아요.
- 지라로 브랜치 생성해보았는데, 브랜치 이름을 잘못작성했네요.. 주의하도록 하겠습니다!
