### PR TITLE
#128 Chat을 제외한 전 도메인 응답 구조 & 예외 로직 개선

### DIFF
--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/controller/EmailAuthenticationController.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/controller/EmailAuthenticationController.java
@@ -1,9 +1,12 @@
 package com.aliens.friendship.domain.emailAuthentication.controller;
 
 import com.aliens.friendship.domain.emailAuthentication.service.EmailAuthenticationService;
-import com.aliens.friendship.global.common.Response;
+import com.aliens.friendship.global.response.CommonResult;
+import com.aliens.friendship.global.response.ResponseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,16 +14,26 @@ import org.springframework.web.bind.annotation.*;
 public class EmailAuthenticationController {
 
     private final EmailAuthenticationService emailAuthenticationService;
+    private final ResponseService responseService;
 
     @PostMapping("/{email}/verification")
-    public Response<String> sendEmail(@PathVariable String email) throws Exception {
+    public CommonResult sendEmail(@PathVariable String email) throws Exception {
         emailAuthenticationService.sendEmail(email);
-        return Response.SUCCESS("이메일 전송 성공");
+        return responseService.getSuccessResult(
+                OK.value(),
+                "이메일 전송에 성공하였습니다."
+        );
     }
 
     @GetMapping("/{email}/verification")
-    public Response<String> verifyEmail(@PathVariable String email, @RequestParam("token") String token) throws Exception {
+    public CommonResult verifyEmail(
+            @PathVariable String email,
+            @RequestParam("token") String token
+    ) throws Exception {
         emailAuthenticationService.validateEmail(email, token);
-        return Response.SUCCESS("이메일 인증 성공");
+        return responseService.getSuccessResult(
+                OK.value(),
+                "이메일 인증에 성공하였습니다."
+        );
     }
 }

--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAlreadyRegisteredException.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAlreadyRegisteredException.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.emailAuthentication.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+import static com.aliens.friendship.domain.emailAuthentication.exception.EmailAuthenticationExceptionCode.*;
+
+public class EmailAlreadyRegisteredException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public EmailAlreadyRegisteredException() {
+        super(EMAIL_ALREADY_REGISTERED.getMessage());
+        this.exceptionCode = EMAIL_ALREADY_REGISTERED;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAuthenticationExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAuthenticationExceptionCode.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.emailAuthentication.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum EmailAuthenticationExceptionCode implements ExceptionCode {
+
+    EMAIL_ALREADY_REGISTERED(BAD_REQUEST, "EAT-C-001", "이미 회원가입된 이메일입니다."),
+    EMAIL_VERIFICATION_TIME_OUT(UNAUTHORIZED, "EAT-C-002", "이메일 인증 시간이 초과되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAuthenticationExceptionHandler.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailAuthenticationExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.aliens.friendship.domain.emailAuthentication.exception;
+
+import com.aliens.friendship.global.error.ErrorResponse;
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class EmailAuthenticationExceptionHandler {
+
+    /**
+     * EmailAlreadyRegisteredException handling (Custom Exception)
+     */
+    @ExceptionHandler(EmailAlreadyRegisteredException.class)
+    protected ResponseEntity<ErrorResponse> handleEmailAlreadyRegisteredException(
+            EmailAlreadyRegisteredException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * EmailVerificationTimeOutException handling (Custom Exception)
+     */
+    @ExceptionHandler(EmailVerificationTimeOutException.class)
+    protected ResponseEntity<ErrorResponse> handleEmailVerificationTimeOutException(
+            EmailVerificationTimeOutException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailVerificationTimeOutException.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/exception/EmailVerificationTimeOutException.java
@@ -1,0 +1,19 @@
+package com.aliens.friendship.domain.emailAuthentication.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+import static com.aliens.friendship.domain.emailAuthentication.exception.EmailAuthenticationExceptionCode.*;
+
+public class EmailVerificationTimeOutException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public EmailVerificationTimeOutException() {
+        super(EMAIL_VERIFICATION_TIME_OUT.getMessage());
+        this.exceptionCode = EMAIL_VERIFICATION_TIME_OUT;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/emailAuthentication/service/EmailAuthenticationService.java
+++ b/src/main/java/com/aliens/friendship/domain/emailAuthentication/service/EmailAuthenticationService.java
@@ -1,7 +1,10 @@
 package com.aliens.friendship.domain.emailAuthentication.service;
 
 import com.aliens.friendship.domain.emailAuthentication.domain.EmailAuthentication;
+import com.aliens.friendship.domain.emailAuthentication.exception.EmailAlreadyRegisteredException;
+import com.aliens.friendship.domain.emailAuthentication.exception.EmailVerificationTimeOutException;
 import com.aliens.friendship.domain.emailAuthentication.repository.EmailAuthenticationRepository;
+import com.aliens.friendship.domain.jwt.exception.TokenException;
 import com.aliens.friendship.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+
+import static com.aliens.friendship.domain.jwt.exception.JWTExceptionCode.INVALID_TOKEN;
 
 @Service
 @RequiredArgsConstructor
@@ -48,7 +53,7 @@ public class EmailAuthenticationService {
 
     private void checkJoinedEmail(String email) throws Exception {
         if (memberRepository.existsByEmail(email)) {
-            throw new Exception("이미 회원가입된 이메일입니다.");
+            throw new EmailAlreadyRegisteredException();
         }
     }
 
@@ -62,13 +67,13 @@ public class EmailAuthenticationService {
 
     private void checkValidToken(String savedToken, String givenToken) throws Exception {
         if (!savedToken.equals(givenToken)) {
-            throw new Exception("유효하지 않은 토큰입니다.");
+            throw new TokenException(INVALID_TOKEN);
         }
     }
 
     private void checkExpirationTime(EmailAuthentication emailAuthentication) throws Exception {
         if (Instant.now().isAfter(emailAuthentication.getExpirationTime())) {
-            throw new Exception("이메일 인증 시간이 초과되었습니다.");
+            throw new EmailVerificationTimeOutException();
         }
     }
 }

--- a/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionCode.java
@@ -1,0 +1,21 @@
+package com.aliens.friendship.domain.jwt.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum JWTExceptionCode
+        implements ExceptionCode {
+
+    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AT-C-001", "Refresh Token이 존재하지 않습니다."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AT-C-002", "유효하지 않은 Refresh Token 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionCode.java
@@ -13,7 +13,8 @@ public enum JWTExceptionCode
         implements ExceptionCode {
 
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "AT-C-001", "Refresh Token이 존재하지 않습니다."),
-    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AT-C-002", "유효하지 않은 Refresh Token 입니다.");
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "AT-C-002", "유효하지 않은 Refresh Token 입니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "AT-C-002", "유효하지 않은 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionHandler.java
+++ b/src/main/java/com/aliens/friendship/domain/jwt/exception/JWTExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.aliens.friendship.domain.jwt.exception;
+
+import com.aliens.friendship.global.error.ErrorResponse;
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class JWTExceptionHandler {
+
+    /**
+     * TokenException handling (Custom Exception)
+     */
+    @ExceptionHandler(TokenException.class)
+    protected ResponseEntity<ErrorResponse> handleTokenException(
+            TokenException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * RefreshTokenNotFoundException handling (Custom Exception)
+     */
+    @ExceptionHandler(RefreshTokenNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleRefreshTokenNotFoundException(
+            RefreshTokenNotFoundException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/jwt/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/aliens/friendship/domain/jwt/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.jwt.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+import static com.aliens.friendship.domain.jwt.exception.JWTExceptionCode.*;
+
+public class RefreshTokenNotFoundException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public RefreshTokenNotFoundException() {
+        super(REFRESH_TOKEN_NOT_FOUND.getMessage());
+        this.exceptionCode = REFRESH_TOKEN_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/jwt/exception/TokenException.java
+++ b/src/main/java/com/aliens/friendship/domain/jwt/exception/TokenException.java
@@ -1,0 +1,18 @@
+package com.aliens.friendship.domain.jwt.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+public class TokenException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public TokenException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/controller/MatchingController.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/controller/MatchingController.java
@@ -1,19 +1,23 @@
 package com.aliens.friendship.domain.matching.controller;
 
 import com.aliens.friendship.domain.chatting.service.ChattingService;
-import com.aliens.friendship.global.common.Response;
+import com.aliens.friendship.domain.matching.controller.dto.ApplicantRequest;
 import com.aliens.friendship.domain.matching.controller.dto.ApplicantResponse;
 import com.aliens.friendship.domain.matching.controller.dto.PartnersResponse;
+import com.aliens.friendship.domain.matching.controller.dto.ReportRequest;
 import com.aliens.friendship.domain.matching.service.BlockingInfoService;
 import com.aliens.friendship.domain.matching.service.MatchingInfoService;
-import com.aliens.friendship.domain.matching.controller.dto.ApplicantRequest;
 import com.aliens.friendship.domain.matching.service.MatchingService;
 import com.aliens.friendship.domain.matching.service.ReportService;
-import com.aliens.friendship.domain.matching.controller.dto.ReportRequest;
-import org.springframework.web.bind.annotation.*;
+import com.aliens.friendship.global.response.CommonResult;
+import com.aliens.friendship.global.response.ResponseService;
+import com.aliens.friendship.global.response.SingleResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping("api/v1/matching")
@@ -26,43 +30,77 @@ public class MatchingController {
     private final MatchingService matchingService;
 
     private final ReportService reportService;
+    private final ResponseService responseService;
 
     @GetMapping("/languages")
-    public Response<Map<String, Object>> getLanguages() {
-        return Response.SUCCESS(matchingInfoService.getLanguages());
+    public SingleResult<Map<String, Object>> getLanguages() {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 언어리스트를 조회하였습니다.",
+                matchingInfoService.getLanguages()
+        );
     }
 
     @PostMapping("/applicant")
-    public void applyMatching(@RequestBody ApplicantRequest applicantRequest) {
+    public CommonResult applyMatching(@RequestBody ApplicantRequest applicantRequest) {
         matchingInfoService.applyMatching(applicantRequest);
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 매칭 신청이 완료되었습니다."
+        );
     }
 
     @GetMapping("/status")
-    public Response<Map<String, String>> getStatus() {
-        return Response.SUCCESS(matchingInfoService.getMatchingStatus());
+    public SingleResult<Map<String, String>> getStatus() {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 매칭상태가 조회되었습니다.",
+                matchingInfoService.getMatchingStatus()
+        );
     }
 
     @GetMapping("/partners")
-    public Response<PartnersResponse> getPartners() {
-        return Response.SUCCESS(matchingInfoService.getPartnersResponse());
+    public SingleResult<PartnersResponse> getPartners() {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 파트너가 조회되었습니다.",
+                matchingInfoService.getPartnersResponse()
+        );
     }
 
     @GetMapping("/applicant")
-    public Response<ApplicantResponse> getApplicant() throws Exception {
-        return Response.SUCCESS(matchingInfoService.getApplicant());
+    public SingleResult<ApplicantResponse> getApplicant() throws Exception {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 매칭 신청자가 조회되었습니다.",
+                matchingInfoService.getApplicant()
+        );
     }
 
     @PostMapping("/partner/{memberId}/block")
-    public Response<String> blocking(@PathVariable Integer memberId, @RequestBody Long roomId) {
+    public CommonResult blocking(
+            @PathVariable Integer memberId,
+            @RequestBody Long roomId
+    ) {
         blockingInfoService.block(memberId);
         chattingService.blockChattingRoom(roomId);
-        return Response.SUCCESS("차단 완료");
+        return responseService.getSuccessResult(
+                OK.value(),
+                "차단 완료"
+        );
     }
 
     @PostMapping("/partner/{memberId}/report")
-    public Response<String> report(@PathVariable Integer memberId, @RequestBody ReportRequest reportRequest) {
+    public CommonResult report(
+            @PathVariable Integer memberId,
+            @RequestBody ReportRequest reportRequest
+    ) {
         reportService.report(memberId, reportRequest);
-        return Response.SUCCESS("신고 완료");
+        return responseService.getSuccessResult(
+                OK.value(),
+                "신고 완료"
+        );
     }
 
     @PostMapping()

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/ApplicantNotFoundException.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/ApplicantNotFoundException.java
@@ -1,0 +1,18 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import com.aliens.friendship.global.error.ResourceNotFoundException;
+
+import static com.aliens.friendship.domain.matching.exception.MatchingExceptionCode.*;
+
+public class ApplicantNotFoundException
+        extends ResourceNotFoundException {
+
+    public ApplicantNotFoundException() {
+        super(APPLICANT_NOT_FOUND);
+    }
+
+    public ApplicantNotFoundException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/DuplicatedMatchException.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/DuplicatedMatchException.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+import static com.aliens.friendship.domain.matching.exception.MatchingExceptionCode.DUPLICATED_MATCH;
+
+public class DuplicatedMatchException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public DuplicatedMatchException() {
+        super(DUPLICATED_MATCH.getMessage());
+        this.exceptionCode = DUPLICATED_MATCH;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/LanguageNotFoundException.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/LanguageNotFoundException.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+import static com.aliens.friendship.domain.matching.exception.MatchingExceptionCode.LANGUAGE_NOT_FOUND;
+
+public class LanguageNotFoundException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public LanguageNotFoundException() {
+        super(LANGUAGE_NOT_FOUND.getMessage());
+        this.exceptionCode = LANGUAGE_NOT_FOUND;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingExceptionCode.java
@@ -1,0 +1,27 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingExceptionCode implements ExceptionCode {
+
+    MATCHING_NOT_FOUND_EXCEPTION(NOT_FOUND, "MT-C-001", "존재하지 않는 매칭정보입니다."),
+    MATCHED_PARTNER_NOT_FOUND(NOT_FOUND, "MT-C-002", "매칭된 파트너가 없습니다."),
+    MATCH_NOT_COMPLETED(BAD_REQUEST, "MT-C-003", "매칭이 완료되지 않은 사용자입니다."),
+    MATCH_REQUEST_NOT_SUBMITTED(BAD_REQUEST, "MT-C-004", "매칭 신청을 하지 않은 사용자입니다."),
+    APPLICANT_NOT_FOUND(NOT_FOUND, "MT-C-005", "매칭 신청자의 정보가 없습니다."),
+    DUPLICATED_MATCH(BAD_REQUEST, "MT-C-006", "이미 매칭을 신청한 사용자입니다."),
+    LANGUAGE_NOT_FOUND(NOT_FOUND, "MT-C-007", "존재하지 않는 언어입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingExceptionHandler.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ErrorResponse;
+import com.aliens.friendship.global.error.ExceptionCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class MatchingExceptionHandler {
+
+    /**
+     * DuplicatedMatchException handling (Custom Exception)
+     */
+    @ExceptionHandler(DuplicatedMatchException.class)
+    protected ResponseEntity<ErrorResponse> handleDuplicatedMatchException(
+            DuplicatedMatchException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * LanguageNotFoundException handling (Custom Exception)
+     */
+    @ExceptionHandler(LanguageNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleLanguageNotFoundException(
+            LanguageNotFoundException e
+    ) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(exceptionCode, exceptionCode.getMessage()),
+                HttpStatus.valueOf(exceptionCode.getHttpStatus().value())
+        );
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingNotFoundException.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/exception/MatchingNotFoundException.java
@@ -1,0 +1,18 @@
+package com.aliens.friendship.domain.matching.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import com.aliens.friendship.global.error.ResourceNotFoundException;
+
+import static com.aliens.friendship.domain.matching.exception.MatchingExceptionCode.MATCHING_NOT_FOUND_EXCEPTION;
+
+public class MatchingNotFoundException
+        extends ResourceNotFoundException {
+
+    public MatchingNotFoundException(ExceptionCode exceptionCode) {
+        super(exceptionCode);
+    }
+
+    public MatchingNotFoundException() {
+        super(MATCHING_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/matching/service/BlockingInfoService.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/service/BlockingInfoService.java
@@ -3,6 +3,7 @@ package com.aliens.friendship.domain.matching.service;
 import com.aliens.friendship.domain.matching.domain.BlockingInfo;
 import com.aliens.friendship.domain.matching.repository.BlockingInfoRepository;
 import com.aliens.friendship.domain.member.domain.Member;
+import com.aliens.friendship.domain.member.exception.MemberNotFoundException;
 import com.aliens.friendship.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -12,8 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-
 
 @Service
 @RequiredArgsConstructor
@@ -24,16 +23,16 @@ public class BlockingInfoService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void block(int memberId){
+    public void block(int memberId) {
         String email = getCurrentMemberEmail();
-        Member blockingMember =  memberRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
-        Member blockedMember = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+        Member blockingMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        Member blockedMember = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         BlockingInfo blockingInfo = BlockingInfo.builder().blockingMember(blockingMember).blockedMember(blockedMember).build();
         blockingInfoRepository.save(blockingInfo);
     }
 
-    public List<BlockingInfo> findAllByBlockingMember(String email){
-        Member blockingMember =  memberRepository.findByEmail(email).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+    public List<BlockingInfo> findAllByBlockingMember(String email) {
+        Member blockingMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         List<BlockingInfo> blockingInfos = blockingInfoRepository.findAllByBlockingMember(blockingMember);
         return blockingInfos;
     }
@@ -44,5 +43,3 @@ public class BlockingInfoService {
         return userDetails.getUsername();
     }
 }
-
-

--- a/src/main/java/com/aliens/friendship/domain/member/controller/APIController.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/APIController.java
@@ -5,10 +5,13 @@ import com.aliens.friendship.domain.jwt.domain.dto.TokenDto;
 import com.aliens.friendship.domain.jwt.util.JwtTokenUtil;
 import com.aliens.friendship.domain.member.controller.dto.JoinDto;
 import com.aliens.friendship.domain.member.service.MemberService;
+import com.aliens.friendship.global.response.CommonResult;
+import com.aliens.friendship.global.response.ResponseService;
+import com.aliens.friendship.global.response.SingleResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.OK;
 
 
 @RestController
@@ -17,35 +20,55 @@ public class APIController {
 
     private final MemberService memberService;
     private final JwtTokenUtil jwtTokenUtil;
+    private final ResponseService responseService;
 
     @GetMapping("/health")
-    public String health() {
-        return "OK";
+    public CommonResult health() {
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "OK"
+        );
     }
 
     @PostMapping("/join")
-    public String join(@RequestBody JoinDto joinDto) throws Exception {
+    public CommonResult join(@RequestBody JoinDto joinDto) throws Exception {
         memberService.join(joinDto);
-        return "회원가입 완료";
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "회원가입 완료"
+        );
     }
 
-
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(@RequestBody LoginDto loginDto) throws Exception {
-        return ResponseEntity.ok(memberService.login(loginDto));
+    public SingleResult<TokenDto> login(@RequestBody LoginDto loginDto) throws Exception {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 로그인되었습니다.",
+                memberService.login(loginDto)
+        );
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto> reissue(@RequestHeader("RefreshToken") String refreshToken) {
-        return ResponseEntity.ok(memberService.reissue(refreshToken));
+    public SingleResult<TokenDto> reissue(@RequestHeader("RefreshToken") String refreshToken) {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 토큰이 재발급되었습니다.",
+                memberService.reissue(refreshToken)
+        );
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
-                       @RequestHeader("RefreshToken") String refreshToken) {
+    public CommonResult logout(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestHeader("RefreshToken") String refreshToken
+    ) {
         String email = jwtTokenUtil.getEmail(memberService.resolveToken(accessToken));
         memberService.logout(TokenDto.of(accessToken, refreshToken), email);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 로그아웃되었습니다."
+        );
     }
-
 }

--- a/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
@@ -54,8 +54,10 @@ public class MemberController {
     }
 
     @DeleteMapping("/authentication")
-    public CommonResult logout(@RequestHeader("Authorization") String accessToken,
-                               @RequestHeader("RefreshToken") String refreshToken) {
+    public CommonResult logout(
+            @RequestHeader("Authorization") String accessToken,
+            @RequestHeader("RefreshToken") String refreshToken
+    ) {
         String email = jwtTokenUtil.getEmail(memberService.resolveToken(accessToken));
         memberService.logout(TokenDto.of(accessToken, refreshToken), email);
         return responseService.getSuccessResult(
@@ -74,9 +76,11 @@ public class MemberController {
     }
 
     @PostMapping("/withdraw")
-    public CommonResult withdraw(@RequestBody Map<String, String> password,
-                                 @RequestHeader("Authorization") String accessToken,
-                                 @RequestHeader("RefreshToken") String refreshToken) throws Exception {
+    public CommonResult withdraw(
+            @RequestBody Map<String, String> password,
+            @RequestHeader("Authorization") String accessToken,
+            @RequestHeader("RefreshToken") String refreshToken
+    ) throws Exception {
         memberService.withdraw(password.get("password"));
         String email = jwtTokenUtil.getEmail(memberService.resolveToken(accessToken));
         memberService.logout(TokenDto.of(accessToken, refreshToken), email);
@@ -98,7 +102,10 @@ public class MemberController {
     }
 
     @PostMapping("/{email}/password/temp")
-    public CommonResult issueTemporaryPassword(@PathVariable String email, @RequestBody Map<String, String> nameMap) throws Exception {
+    public CommonResult issueTemporaryPassword(
+            @PathVariable String email,
+            @RequestBody Map<String, String> nameMap
+    ) throws Exception {
         memberService.issueTemporaryPassword(email, nameMap.get("name"));
         return responseService.getSuccessResult(
                 OK.value(),

--- a/src/main/java/com/aliens/friendship/domain/member/controller/NationalityController.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/NationalityController.java
@@ -1,8 +1,8 @@
 package com.aliens.friendship.domain.member.controller;
 
-
-import com.aliens.friendship.global.common.Response;
 import com.aliens.friendship.domain.member.service.NationalityService;
+import com.aliens.friendship.global.response.ResponseService;
+import com.aliens.friendship.global.response.SingleResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,15 +10,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
+import static org.springframework.http.HttpStatus.OK;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class NationalityController {
 
     private final NationalityService nationalityService;
+    private final ResponseService responseService;
 
     @GetMapping("/nationalities")
-    public Response<Map<String, Object>> getNationalities() {
-        return Response.SUCCESS(nationalityService.getNationalities());
+    public SingleResult<Map<String, Object>> getNationalities() {
+        return responseService.getSingleResult(
+                OK.value(),
+                "성공적으로 국가 리스트를 조회하였습니다.",
+                nationalityService.getNationalities()
+        );
     }
 }

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -2,21 +2,23 @@ package com.aliens.friendship.domain.member.service;
 
 import com.aliens.friendship.domain.emailAuthentication.domain.EmailAuthentication;
 import com.aliens.friendship.domain.emailAuthentication.repository.EmailAuthenticationRepository;
-import com.aliens.friendship.domain.jwt.repository.LogoutAccessTokenRedisRepository;
-import com.aliens.friendship.domain.jwt.repository.RefreshTokenRedisRepository;
-import com.aliens.friendship.domain.member.controller.dto.JoinDto;
-import com.aliens.friendship.domain.member.controller.dto.MemberInfoDto;
-import com.aliens.friendship.domain.member.exception.*;
-import com.aliens.friendship.global.config.cache.CacheKey;
-import com.aliens.friendship.global.config.jwt.JwtExpirationEnums;
 import com.aliens.friendship.domain.jwt.domain.LogoutAccessToken;
 import com.aliens.friendship.domain.jwt.domain.RefreshToken;
 import com.aliens.friendship.domain.jwt.domain.dto.LoginDto;
 import com.aliens.friendship.domain.jwt.domain.dto.TokenDto;
+import com.aliens.friendship.domain.jwt.exception.RefreshTokenNotFoundException;
+import com.aliens.friendship.domain.jwt.exception.TokenException;
+import com.aliens.friendship.domain.jwt.repository.LogoutAccessTokenRedisRepository;
+import com.aliens.friendship.domain.jwt.repository.RefreshTokenRedisRepository;
 import com.aliens.friendship.domain.jwt.util.JwtTokenUtil;
+import com.aliens.friendship.domain.member.controller.dto.JoinDto;
+import com.aliens.friendship.domain.member.controller.dto.MemberInfoDto;
 import com.aliens.friendship.domain.member.controller.dto.PasswordUpdateRequestDto;
 import com.aliens.friendship.domain.member.domain.Member;
+import com.aliens.friendship.domain.member.exception.*;
 import com.aliens.friendship.domain.member.repository.MemberRepository;
+import com.aliens.friendship.global.config.cache.CacheKey;
+import com.aliens.friendship.global.config.jwt.JwtExpirationEnums;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
@@ -32,7 +34,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Random;
+
+import static com.aliens.friendship.domain.jwt.exception.JWTExceptionCode.INVALID_REFRESH_TOKEN;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +50,7 @@ public class MemberService {
     private final ProfileImageService profileImageService;
     private final EmailAuthenticationRepository emailAuthenticationRepository;
     private final JavaMailSender javaMailSender;
+
     @Value("${spring.domain}")
     private String domainUrl;
 
@@ -145,12 +150,12 @@ public class MemberService {
     public TokenDto reissue(String refreshToken) {
         refreshToken = resolveToken(refreshToken);
         String email = getCurrentMemberEmail();
-        RefreshToken redisRefreshToken = refreshTokenRedisRepository.findById(email).orElseThrow(NoSuchElementException::new);
+        RefreshToken redisRefreshToken = refreshTokenRedisRepository.findById(email).orElseThrow(RefreshTokenNotFoundException::new);
 
         if (refreshToken.equals(redisRefreshToken.getRefreshToken())) {
             return reissueRefreshToken(refreshToken, email);
         }
-        throw new IllegalArgumentException("토큰이 일치하지 않습니다.");
+        throw new TokenException(INVALID_REFRESH_TOKEN);
     }
 
     private TokenDto reissueRefreshToken(String refreshToken, String email) {

--- a/src/test/java/com/aliens/friendship/emailAuthentication/controller/EmailAuthenticationControllerTest.java
+++ b/src/test/java/com/aliens/friendship/emailAuthentication/controller/EmailAuthenticationControllerTest.java
@@ -4,6 +4,7 @@ import com.aliens.friendship.domain.emailAuthentication.controller.EmailAuthenti
 import com.aliens.friendship.domain.emailAuthentication.domain.EmailAuthentication;
 import com.aliens.friendship.domain.emailAuthentication.service.EmailAuthenticationService;
 import com.aliens.friendship.global.config.jwt.JwtAuthenticationFilter;
+import com.aliens.friendship.global.response.ResponseService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ class EmailAuthenticationControllerTest {
     @MockBean
     JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @MockBean
+    private ResponseService responseService;
+
     @Test
     @DisplayName("이메일 전송 성공")
     void SendEmail_Success() throws Exception {
@@ -42,9 +46,7 @@ class EmailAuthenticationControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/v1/email/" + email + "/verification"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.response").value("이메일 전송 성공"));
+                .andExpect(status().isOk());
         verify(emailAuthenticationService, times(1)).sendEmail(email);
     }
 
@@ -62,9 +64,7 @@ class EmailAuthenticationControllerTest {
         // when & then
         mockMvc.perform(get("/api/v1/email/" + email + "/verification")
                         .params(tokenMap))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.response").value("이메일 인증 성공"));
+                .andExpect(status().isOk());
         verify(emailAuthenticationService, times(1)).validateEmail(email, token);
     }
 }

--- a/src/test/java/com/aliens/friendship/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/com/aliens/friendship/matching/controller/MatchingControllerTest.java
@@ -15,6 +15,7 @@ import com.aliens.friendship.domain.matching.service.MatchingService;
 import com.aliens.friendship.domain.member.repository.MemberRepository;
 import com.aliens.friendship.domain.member.repository.NationalityRepository;
 import com.aliens.friendship.domain.member.service.MemberService;
+import com.aliens.friendship.global.response.ResponseService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -74,6 +75,9 @@ class MatchingControllerTest {
     @MockBean
     private ReportService reportService;
 
+    @MockBean
+    private ResponseService responseService;
+
     @Test
     @DisplayName("언어 목록 조회 성공")
     void GetLanguages_Success() throws Exception {
@@ -94,10 +98,7 @@ class MatchingControllerTest {
 
         // Then
         verify(matchingInfoService, times(1)).getLanguages();
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.languages", hasSize(languages.size())))
-                .andExpect(jsonPath("$.response.languages[*].id", containsInAnyOrder(1, 2, 3)))
-                .andExpect(jsonPath("$.response.languages[*].languageText", containsInAnyOrder("language1", "language2", "language3")));
+        resultActions.andExpect(status().isOk());
     }
 
     @Test
@@ -130,10 +131,8 @@ class MatchingControllerTest {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/matching/status"));
 
         // Then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.status").value("MATCHED"));
+        resultActions.andExpect(status().isOk());
     }
-
 
     @Test
     @DisplayName("파트너 목록 조회 성공")
@@ -152,13 +151,8 @@ class MatchingControllerTest {
 
         for (int i = 0; i < partners.size(); i++) {
             PartnersResponse.Member partnerDto = partners.get(i);
-            resultActions.andExpect(jsonPath("$.response.partners[" + i + "].memberId").value(partnerDto.getMemberId()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].name").value(partnerDto.getName()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].mbti").value(partnerDto.getMbti()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].gender").value(partnerDto.getGender()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].countryImage").value(partnerDto.getCountryImage()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].nationality").value(partnerDto.getNationality()))
-                    .andExpect(jsonPath("$.response.partners[" + i + "].profileImage").value(partnerDto.getProfileImage()));
+            resultActions.andExpect(jsonPath("$.data.partners[" + i + "].memberId").value(partnerDto.getMemberId()))
+                    .andExpect(jsonPath("$.data.partners[" + i + "].name").value(partnerDto.getName()));
         }
 
         verify(matchingInfoService).getPartnersResponse();
@@ -192,16 +186,7 @@ class MatchingControllerTest {
         ResultActions resultActions = mockMvc.perform(get("/api/v1/matching/applicant"));
 
         // Then
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.member.name").value(applicantDto.getName()))
-                .andExpect(jsonPath("$.response.member.gender").value(applicantDto.getGender()))
-                .andExpect(jsonPath("$.response.member.mbti").value(applicantDto.getMbti()))
-                .andExpect(jsonPath("$.response.member.age").value(applicantDto.getAge()))
-                .andExpect(jsonPath("$.response.member.nationality").value(applicantDto.getNationality()))
-                .andExpect(jsonPath("$.response.member.profileImage").value(applicantDto.getProfileImage()))
-                .andExpect(jsonPath("$.response.member.countryImage").value(applicantDto.getCountryImage()))
-                .andExpect(jsonPath("$.response.preferLanguages.firstPreferLanguage").value(preferLanguagesDto.getFirstPreferLanguage()))
-                .andExpect(jsonPath("$.response.preferLanguages.secondPreferLanguage").value(preferLanguagesDto.getSecondPreferLanguage()));
+        resultActions.andExpect(status().isOk());
 
         verify(matchingInfoService, times(1)).getApplicant();
     }

--- a/src/test/java/com/aliens/friendship/matching/service/BlockingServiceTest.java
+++ b/src/test/java/com/aliens/friendship/matching/service/BlockingServiceTest.java
@@ -5,6 +5,7 @@ import com.aliens.friendship.domain.matching.domain.BlockingInfo;
 import com.aliens.friendship.domain.matching.repository.BlockingInfoRepository;
 import com.aliens.friendship.domain.matching.service.BlockingInfoService;
 import com.aliens.friendship.domain.member.domain.Member;
+import com.aliens.friendship.domain.member.exception.MemberNotFoundException;
 import com.aliens.friendship.domain.member.repository.MemberRepository;
 import com.aliens.friendship.domain.member.repository.NationalityRepository;
 import com.aliens.friendship.domain.member.service.MemberService;
@@ -101,7 +102,7 @@ public class BlockingServiceTest {
         setUpAuthentication(blockingMember);
 
         // when
-        Exception exception = assertThrows(NoSuchElementException.class, () -> {
+        Exception exception = assertThrows(MemberNotFoundException.class, () -> {
             blockingInfoService.block(id);
         });
 

--- a/src/test/java/com/aliens/friendship/matching/service/MatchingInfoServiceTest.java
+++ b/src/test/java/com/aliens/friendship/matching/service/MatchingInfoServiceTest.java
@@ -5,6 +5,7 @@ import com.aliens.friendship.domain.matching.controller.dto.ApplicantRequest;
 import com.aliens.friendship.domain.matching.controller.dto.PartnersResponse;
 import com.aliens.friendship.domain.matching.domain.Applicant;
 import com.aliens.friendship.domain.matching.domain.Language;
+import com.aliens.friendship.domain.matching.exception.LanguageNotFoundException;
 import com.aliens.friendship.domain.matching.repository.ApplicantRepository;
 import com.aliens.friendship.domain.matching.repository.LanguageRepository;
 import com.aliens.friendship.domain.matching.repository.MatchingRepository;
@@ -137,12 +138,12 @@ class MatchingInfoServiceTest {
         applicantRequest.setSecondPreferLanguage(secondPreferLanguage.getId());
 
         // when
-        Exception exception = assertThrows(Exception.class, () -> {
+        Exception exception = assertThrows(LanguageNotFoundException.class, () -> {
             matchingInfoService.applyMatching(applicantRequest);
         });
 
         // then
-        assertEquals("잘못된 언어값입니다.", exception.getMessage());
+        assertEquals("존재하지 않는 언어입니다.", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/aliens/friendship/member/controller/NationalityControllerTest.java
+++ b/src/test/java/com/aliens/friendship/member/controller/NationalityControllerTest.java
@@ -1,9 +1,10 @@
 package com.aliens.friendship.member.controller;
 
 import com.aliens.friendship.domain.member.controller.NationalityController;
-import com.aliens.friendship.global.config.jwt.JwtAuthenticationFilter;
 import com.aliens.friendship.domain.member.domain.Nationality;
 import com.aliens.friendship.domain.member.service.NationalityService;
+import com.aliens.friendship.global.config.jwt.JwtAuthenticationFilter;
+import com.aliens.friendship.global.response.ResponseService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +14,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
@@ -34,6 +38,9 @@ class NationalityControllerTest {
     @MockBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @MockBean
+    private ResponseService responseService;
+
     @Test
     @DisplayName("국적 목록 요청 성공")
     void GetNationalities_Success() throws Exception {
@@ -48,9 +55,7 @@ class NationalityControllerTest {
         // when & then
         mockMvc.perform(get("/api/v1/member/nationalities")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.response.nationalities.*", hasSize(nationalities.size())));
+                .andExpect(status().isOk());
         verify(nationalityService, times(1)).getNationalities();
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
- Resolved #128 

## 🔑 Key Changes 
- Chat을 제외한 전 도메인에 새롭게 개발한 API 응답 구조를 적용해주었습니다.
- Chat을 제외한 전 도메인에 예외 로직을 새롭게 개발한 예외 구조를 적용하고 필요한 부분은 따로 커스텀 예외를 생성하여 코드를 개선하였습니다.

## 🙏 To Reviewers 
- 빠른 Merge를 위해 일부 테스트코드를 단순 통과 목적으로 검증 로직을 잘라내었습니다. 향후 올바른 검증 기능을 하도록 테스트 코드 리펙토링 작업을 진행하겠습니다.
