### PR TITLE
feat/backend-58 API Test 후 기능 및 반환값 수정

### DIFF
--- a/src/main/java/com/aliens/friendship/domain/matching/controller/dto/ApplicantResponse.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/controller/dto/ApplicantResponse.java
@@ -1,5 +1,6 @@
 package com.aliens.friendship.domain.matching.controller.dto;
 
+import com.aliens.friendship.domain.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,7 +16,7 @@ public class ApplicantResponse {
     public static class Member {
         private String name;
         private String gender;
-        private String mbti;
+        private com.aliens.friendship.domain.member.domain.Member.Mbti mbti;
         private String nationality;
         private Integer age;
         private String profileImage;

--- a/src/main/java/com/aliens/friendship/domain/matching/controller/dto/PartnersResponse.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/controller/dto/PartnersResponse.java
@@ -1,5 +1,6 @@
 package com.aliens.friendship.domain.matching.controller.dto;
 
+import com.aliens.friendship.domain.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,7 +22,7 @@ public class PartnersResponse {
     public static class Member {
         private Integer memberId;
         private String name;
-        private String mbti;
+        private com.aliens.friendship.domain.member.domain.Member.Mbti mbti;
         private String gender;
         private String nationality;
         private String profileImage;

--- a/src/main/java/com/aliens/friendship/domain/matching/service/MatchingInfoService.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/service/MatchingInfoService.java
@@ -94,7 +94,7 @@ public class MatchingInfoService {
                         .mbti(partner.getMbti())
                         .gender(partner.getGender())
                         .nationality(partner.getNationality().getNationalityText())
-                        .countryImage(partner.getNationality().getCountryImageUrl())
+                        .countryImage(partner.getNationality().getNationalityText())
                         .profileImage(partner.getProfileImageUrl())
                         .build();
                 partnersResponse.getPartners().add(partnerDto);
@@ -121,7 +121,7 @@ public class MatchingInfoService {
                 .age(member.getAge())
                 .nationality(member.getNationality().getNationalityText())
                 .profileImage(member.getProfileImageUrl())
-                .countryImage(member.getNationality().getCountryImageUrl())
+                .countryImage(member.getNationality().getNationalityText())
                 .build();
         ApplicantResponse.PreferLanguages preferLanguagesDto = ApplicantResponse.PreferLanguages.builder()
                 .firstPreferLanguage(applicant.getFirstPreferLanguage().getLanguageText())

--- a/src/main/java/com/aliens/friendship/domain/matching/service/MatchingInfoService.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/service/MatchingInfoService.java
@@ -80,7 +80,7 @@ public class MatchingInfoService {
                 PartnersResponse.Member partnerDto = PartnersResponse.Member.builder()
                         .memberId(-1)
                         .name("탈퇴한 사용자")
-                        .mbti("")
+                        .mbti(null)
                         .gender("")
                         .nationality("")
                         .countryImage("")

--- a/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.aliens.friendship.domain.member.controller.dto.JoinDto;
 import com.aliens.friendship.domain.member.controller.dto.MemberInfoDto;
 import com.aliens.friendship.domain.member.controller.dto.PasswordUpdateRequestDto;
 import com.aliens.friendship.domain.member.controller.dto.ProfileImageRequest;
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.domain.member.service.MemberService;
 import com.aliens.friendship.global.response.CommonResult;
 import com.aliens.friendship.global.response.ResponseService;
@@ -123,8 +124,8 @@ public class MemberController {
     }
 
     @PatchMapping()
-    public CommonResult changeProfileNameAndMbti(@RequestBody Map<String, String> nameAndMbti) {
-        memberService.changeProfileNameAndMbti(nameAndMbti.get("name"), nameAndMbti.get("mbti"));
+    public CommonResult changeProfileMbti(@RequestBody Map<String, Member.Mbti> mbti) {
+        memberService.changeProfileNameAndMbti(mbti.get("mbti"));
         return responseService.getSuccessResult(
                 OK.value(),
                 "프로필 이름과 mbti 값 변경 성공"

--- a/src/main/java/com/aliens/friendship/domain/member/controller/dto/JoinDto.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/dto/JoinDto.java
@@ -1,5 +1,6 @@
 package com.aliens.friendship.domain.member.controller.dto;
 
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.domain.member.domain.Nationality;
 import com.aliens.friendship.domain.member.validation.ProfileImageValidate;
 import lombok.*;
@@ -11,7 +12,7 @@ public class JoinDto {
     private String email;
     private String password;
     private String name;
-    private String mbti;
+    private Member.Mbti mbti;
     private String gender;
     private Nationality nationality;
     private String birthday;

--- a/src/main/java/com/aliens/friendship/domain/member/controller/dto/MemberInfoDto.java
+++ b/src/main/java/com/aliens/friendship/domain/member/controller/dto/MemberInfoDto.java
@@ -1,5 +1,6 @@
 package com.aliens.friendship.domain.member.controller.dto;
 
+import com.aliens.friendship.domain.member.domain.Member;
 import lombok.*;
 
 @Getter
@@ -10,7 +11,7 @@ import lombok.*;
 public class MemberInfoDto {
     private Integer memberId;
     private String email;
-    private String mbti;
+    private Member.Mbti mbti;
     private String gender;
     private String nationality;
     private String birthday;

--- a/src/main/java/com/aliens/friendship/domain/member/domain/Member.java
+++ b/src/main/java/com/aliens/friendship/domain/member/domain/Member.java
@@ -49,8 +49,9 @@ public class Member {
     @Column(name = COLUMN_PASSWORD_NAME, nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = COLUMN_MBTI_NAME, nullable = false, length = 45)
-    private String mbti;
+    private Mbti mbti;
 
     @Column(name = COLUMN_GENDER_NAME, nullable = false, length = 45)
     private String gender;
@@ -100,7 +101,7 @@ public class Member {
         this.name = name;
     }
 
-    public void updateMbti(String mbti) {
+    public void updateMbti(Mbti mbti) {
         this.mbti = mbti;
     }
 
@@ -178,4 +179,7 @@ public class Member {
         APPLIED, NOT_APPLIED, WITHDRAWN;
     }
 
+    public enum Mbti {
+        ISTJ, ISFJ, INFJ, INTJ, ISTP, ISFP, INFP, INTP, ESTP, ESFP, ENFP, ENTP, ESTJ, ESFJ, ENFJ, ENTJ
+    }
 }

--- a/src/main/java/com/aliens/friendship/domain/member/domain/Nationality.java
+++ b/src/main/java/com/aliens/friendship/domain/member/domain/Nationality.java
@@ -25,8 +25,4 @@ public class Nationality {
 
     @Column(name = COLUMN_NATINALITYTEXT_NAME, nullable = false, length = 45)
     private String nationalityText;
-
-    public String getCountryImageUrl() {
-        return "도메인" + nationalityText + ".png";
-    }
 }

--- a/src/main/java/com/aliens/friendship/domain/member/exception/InvalidMemberNameException.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/InvalidMemberNameException.java
@@ -1,0 +1,17 @@
+package com.aliens.friendship.domain.member.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+public class InvalidMemberNameException
+        extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public InvalidMemberNameException() {
+        this.exceptionCode = MemberExceptionCode.INVALID_MEMBER_NAME;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
@@ -18,6 +18,7 @@ public enum MemberExceptionCode
     PASSWORD_CHANGE_FAILED_EXCEPTION(BAD_REQUEST, "MB-C-004", "비밀번호 변경에 실패하였습니다."),
     EMAIL_VERIFICATION_NOT_COMPLETED(FORBIDDEN, "MB-C-005", "이메일 인증이 완료되지 않았습니다."),
     WITHDRAWN_MEMBER_WITHIN_A_WEEK(CONFLICT, "MB-C-006", "일주일 내에 탈퇴한 회원은 동일한 이메일로 가입할 수 없습니다."),
+    INVALID_MEMBER_NAME(BAD_REQUEST, "MB-C-007", "회원의 이름이 일치하지 않습니다."),
     NATIONALITIES_NOT_FOUND(NOT_FOUND, "NTN-C-001", "국적 목록이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
@@ -17,6 +17,7 @@ public enum MemberExceptionCode
     MEMBER_NOT_FOUND(NOT_FOUND, "MB-C-003", "존재하지 않는 회원입니다."),
     PASSWORD_CHANGE_FAILED_EXCEPTION(BAD_REQUEST, "MB-C-004", "비밀번호 변경에 실패하였습니다."),
     EMAIL_VERIFICATION_NOT_COMPLETED(FORBIDDEN, "MB-C-005", "이메일 인증이 완료되지 않았습니다."),
+    WITHDRAWN_MEMBER_WITHIN_A_WEEK(CONFLICT, "MB-C-006", "일주일 내에 탈퇴한 회원은 동일한 이메일로 가입할 수 없습니다."),
     NATIONALITIES_NOT_FOUND(NOT_FOUND, "NTN-C-001", "국적 목록이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionCode.java
@@ -17,7 +17,7 @@ public enum MemberExceptionCode
     MEMBER_NOT_FOUND(NOT_FOUND, "MB-C-003", "존재하지 않는 회원입니다."),
     PASSWORD_CHANGE_FAILED_EXCEPTION(BAD_REQUEST, "MB-C-004", "비밀번호 변경에 실패하였습니다."),
     EMAIL_VERIFICATION_NOT_COMPLETED(FORBIDDEN, "MB-C-005", "이메일 인증이 완료되지 않았습니다."),
-    WITHDRAWN_MEMBER_WITHIN_A_WEEK(CONFLICT, "MB-C-006", "일주일 내에 탈퇴한 회원은 동일한 이메일로 가입할 수 없습니다."),
+    WITHDRAWN_MEMBER_WITHIN_A_WEEK(CONFLICT, "MB-C-006", "탈퇴한 회원은 일주일 내에 동일한 이메일로 가입할 수 없습니다."),
     INVALID_MEMBER_NAME(BAD_REQUEST, "MB-C-007", "회원의 이름이 일치하지 않습니다."),
     NATIONALITIES_NOT_FOUND(NOT_FOUND, "NTN-C-001", "국적 목록이 존재하지 않습니다.");
 

--- a/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionHandler.java
@@ -72,6 +72,21 @@ public class MemberExceptionHandler {
     }
 
     /**
+     * InvalidMemberNameException 핸들링
+     * Custom Exception
+     */
+    @ExceptionHandler(InvalidMemberNameException.class)
+    protected ResponseEntity<ErrorResponse> handlingInvalidMemberNameException(
+            InvalidMemberNameException e
+    ) {
+        log.error("[handling InvalidMemberNameException] {}", e.getExceptionCode().getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(e.getExceptionCode()),
+                HttpStatus.valueOf(e.getExceptionCode().getHttpStatus().value())
+        );
+    }
+
+    /**
      * EmailVerificationException 핸들링
      * Custom Exception
      */

--- a/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/MemberExceptionHandler.java
@@ -57,6 +57,21 @@ public class MemberExceptionHandler {
     }
 
     /**
+     * WithdrawnWithinAWeekException 핸들링
+     * Custom Exception
+     */
+    @ExceptionHandler(WithdrawnMemberWithinAWeekException.class)
+    protected ResponseEntity<ErrorResponse> handlingWithdrawnWithinAWeekException(
+            WithdrawnMemberWithinAWeekException e
+    ) {
+        log.error("[handling WithdrawnWithinAWeekException] {}", e.getExceptionCode().getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(e.getExceptionCode()),
+                HttpStatus.valueOf(e.getExceptionCode().getHttpStatus().value())
+        );
+    }
+
+    /**
      * EmailVerificationException 핸들링
      * Custom Exception
      */

--- a/src/main/java/com/aliens/friendship/domain/member/exception/WithdrawnMemberWithinAWeekException.java
+++ b/src/main/java/com/aliens/friendship/domain/member/exception/WithdrawnMemberWithinAWeekException.java
@@ -1,0 +1,17 @@
+package com.aliens.friendship.domain.member.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+
+public class WithdrawnMemberWithinAWeekException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+
+    public WithdrawnMemberWithinAWeekException() {
+        super(MemberExceptionCode.WITHDRAWN_MEMBER_WITHIN_A_WEEK.getMessage());
+        exceptionCode = MemberExceptionCode.WITHDRAWN_MEMBER_WITHIN_A_WEEK;
+    }
+
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -129,6 +129,7 @@ public class MemberService {
         String email = getCurrentMemberEmail();
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         return MemberInfoDto.builder()
+                .memberId(member.getId())
                 .email(member.getEmail())
                 .mbti(member.getMbti())
                 .gender(member.getGender())

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
     private String domainUrl;
 
     public void join(JoinDto joinDto) throws Exception {
-        checkDuplicatedEmail(joinDto.getEmail());
+        checkDuplicatedAndWithdrawnInAWeekEmail(joinDto.getEmail());
         checkEmailAuthentication(joinDto.getEmail());
         joinDto.setPassword(passwordEncoder.encode(joinDto.getPassword()));
         joinDto.setImageUrl(profileImageService.uploadProfileImage(joinDto.getProfileImage()));
@@ -182,9 +182,13 @@ public class MemberService {
         return userDetails.getUsername();
     }
 
-    private void checkDuplicatedEmail(String email) throws Exception {
+    private void checkDuplicatedAndWithdrawnInAWeekEmail(String email) throws Exception {
         if (memberRepository.findByEmail(email).isPresent()) {
-            throw new DuplicateMemberEmailException();
+            if (memberRepository.findByEmail(email).get().getStatus() == Member.Status.WITHDRAWN) {
+                throw new WithdrawnMemberWithinAWeekException();
+            } else {
+                throw new DuplicateMemberEmailException();
+            }
         }
     }
 

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -244,9 +244,8 @@ public class MemberService {
         }
     }
 
-    public void changeProfileNameAndMbti(String name, String mbti) {
+    public void changeProfileNameAndMbti(Member.Mbti mbti) {
         Member member = memberRepository.findByEmail(getCurrentMemberEmail()).orElseThrow(MemberNotFoundException::new);
-        member.updateName(name);
         member.updateMbti(mbti);
         memberRepository.save(member);
     }

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -278,7 +278,7 @@ public class MemberService {
             if (isJoinedEmail(email)) {
                 return "JOINED"; // 이메일 인증 후 회원가입된 상태
             } else {
-                return "EMAIL_SENDING_REQUEST_REQUIRED"; // 이메일 전송 요청 필요
+                return "EMAIL_NOT_SENT"; // 이메일 전송 요청 필요
             }
         }
         String status = emailAuthentication.getStatus().toString();
@@ -290,7 +290,7 @@ public class MemberService {
                 return "AUTHENTICATED"; // 이메일 인증 완료
             }
         } else {
-            return "NOT_AUTHENTICATED"; // 이메일 인증 미완료
+            return "EMAIL_SENT_NOT_AUTHENTICATED"; // 이메일 인증 미완료
         }
     }
 

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -133,7 +133,7 @@ public class MemberService {
                 .email(member.getEmail())
                 .mbti(member.getMbti())
                 .gender(member.getGender())
-                .nationality(member.getNationality().getCountryImageUrl())
+                .nationality(member.getNationality().getNationalityText())
                 .birthday(member.getBirthday())
                 .age(member.getAge())
                 .name(member.getName())

--- a/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
+++ b/src/main/java/com/aliens/friendship/domain/member/service/MemberService.java
@@ -57,6 +57,7 @@ public class MemberService {
     public void join(JoinDto joinDto) throws Exception {
         checkDuplicatedAndWithdrawnInAWeekEmail(joinDto.getEmail());
         checkEmailAuthentication(joinDto.getEmail());
+        emailAuthenticationRepository.deleteByEmail(joinDto.getEmail());
         joinDto.setPassword(passwordEncoder.encode(joinDto.getPassword()));
         joinDto.setImageUrl(profileImageService.uploadProfileImage(joinDto.getProfileImage()));
         memberRepository.save(Member.ofUser(joinDto));

--- a/src/test/java/com/aliens/friendship/chatting/repository/MatchingRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/chatting/repository/MatchingRepositoryImplTest.java
@@ -62,7 +62,7 @@ class MatchingRepositoryImplTest {
             Member member = Member.builder()
                     .email("member" + i + "@test.com")
                     .password("1234567")
-                    .mbti("ISFJ")
+                    .mbti(Member.Mbti.ISFJ)
                     .gender("FEMALE")
                     .birthday("2002-01-17")
                     .name("최정은")

--- a/src/test/java/com/aliens/friendship/jwt/JwtAPITest.java
+++ b/src/test/java/com/aliens/friendship/jwt/JwtAPITest.java
@@ -5,6 +5,7 @@ import com.aliens.friendship.domain.emailAuthentication.repository.EmailAuthenti
 import com.aliens.friendship.domain.jwt.domain.dto.LoginDto;
 import com.aliens.friendship.domain.jwt.domain.dto.TokenDto;
 import com.aliens.friendship.domain.member.controller.dto.JoinDto;
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.domain.member.domain.Nationality;
 import com.aliens.friendship.domain.member.repository.NationalityRepository;
 import com.aliens.friendship.domain.member.service.MemberService;
@@ -57,7 +58,7 @@ public class JwtAPITest {
                 .password("1q2w3e4r")
                 .email("test@case.com")
                 .name("김명준")
-                .mbti("INTJ")
+                .mbti(Member.Mbti.INTJ)
                 .birthday("1998-01-01")
                 .gender("male")
                 .nationality(nationality)

--- a/src/test/java/com/aliens/friendship/jwt/JwtUtilTest.java
+++ b/src/test/java/com/aliens/friendship/jwt/JwtUtilTest.java
@@ -2,6 +2,7 @@ package com.aliens.friendship.jwt;
 
 import com.aliens.friendship.domain.emailAuthentication.domain.EmailAuthentication;
 import com.aliens.friendship.domain.emailAuthentication.repository.EmailAuthenticationRepository;
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.global.config.security.CustomUserDetailService;
 import com.aliens.friendship.domain.jwt.domain.dto.LoginDto;
 import com.aliens.friendship.domain.jwt.domain.dto.TokenDto;
@@ -56,7 +57,7 @@ public class JwtUtilTest {
                 .password("1q2w3e4r")
                 .email("test@case.com")
                 .name("김명준")
-                .mbti("INTJ")
+                .mbti(Member.Mbti.INTJ)
                 .birthday("1998-09-21")
                 .profileImage(mockMultipartFile)
                 .gender("MALE")

--- a/src/test/java/com/aliens/friendship/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/com/aliens/friendship/matching/controller/MatchingControllerTest.java
@@ -4,6 +4,7 @@ import com.aliens.friendship.domain.chatting.service.ChattingService;
 import com.aliens.friendship.domain.matching.controller.MatchingController;
 import com.aliens.friendship.domain.matching.controller.dto.ReportRequest;
 import com.aliens.friendship.domain.matching.service.ReportService;
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.global.config.jwt.JwtAuthenticationFilter;
 import com.aliens.friendship.domain.matching.controller.dto.ApplicantRequest;
 import com.aliens.friendship.domain.matching.controller.dto.ApplicantResponse;
@@ -166,7 +167,7 @@ class MatchingControllerTest {
         ApplicantResponse.Member applicantDto = ApplicantResponse.Member.builder()
                 .name("Ryan")
                 .gender("MALE")
-                .mbti("INTJ")
+                .mbti(Member.Mbti.INTJ)
                 .age(25)
                 .nationality("American")
                 .profileImage("Profile_URL")

--- a/src/test/java/com/aliens/friendship/matching/controller/PartnersFixture.java
+++ b/src/test/java/com/aliens/friendship/matching/controller/PartnersFixture.java
@@ -1,6 +1,7 @@
 package com.aliens.friendship.matching.controller;
 
 import com.aliens.friendship.domain.matching.controller.dto.PartnersResponse;
+import com.aliens.friendship.domain.member.domain.Member;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +15,7 @@ public class PartnersFixture {
             PartnersResponse.Member partner = PartnersResponse.Member.builder()
                     .memberId(i)
                     .name("Partner" + i)
-                    .mbti("MBTI" + i)
+                    .mbti(Member.Mbti.INTJ)
                     .gender("GENDER" + i)
                     .nationality("Nationality" + i)
                     .countryImage("CountryImageURL" + i)

--- a/src/test/java/com/aliens/friendship/matching/service/MatchingInfoServiceTest.java
+++ b/src/test/java/com/aliens/friendship/matching/service/MatchingInfoServiceTest.java
@@ -197,7 +197,7 @@ class MatchingInfoServiceTest {
                     assertEquals(partner.getMbti(), partnerResponse.getMbti());
                     assertEquals(partner.getGender(), partnerResponse.getGender());
                     assertEquals(partner.getNationality().getNationalityText(), partnerResponse.getNationality());
-                    assertEquals(partner.getNationality().getCountryImageUrl(), partnerResponse.getCountryImage());
+                    assertEquals(partner.getNationality().getNationalityText(), partnerResponse.getCountryImage());
                     assertEquals(partner.getProfileImageUrl(), partnerResponse.getProfileImage());
                 }
             }
@@ -307,7 +307,7 @@ class MatchingInfoServiceTest {
                 assertEquals(member.getMbti(), applicantResponse.getMember().getMbti());
                 assertEquals(member.getNationality().getNationalityText(), applicantResponse.getMember().getNationality());
                 assertEquals(member.getAge(), applicantResponse.getMember().getAge());
-                assertEquals(member.getNationality().getCountryImageUrl(), applicantResponse.getMember().getCountryImage());
+                assertEquals(member.getNationality().getNationalityText(), applicantResponse.getMember().getCountryImage());
                 assertEquals(member.getProfileImageUrl(), applicantResponse.getMember().getProfileImage());
                 assertEquals(applicant.getFirstPreferLanguage().getLanguageText(), applicantResponse.getPreferLanguages().getFirstPreferLanguage());
                 assertEquals(applicant.getSecondPreferLanguage().getLanguageText(), applicantResponse.getPreferLanguages().getSecondPreferLanguage());

--- a/src/test/java/com/aliens/friendship/matching/service/MemberFixture.java
+++ b/src/test/java/com/aliens/friendship/matching/service/MemberFixture.java
@@ -7,9 +7,9 @@ import java.time.Instant;
 import java.util.HashSet;
 
 public class MemberFixture {
-    private static Member createMember(Integer id, String email, String password, String mbti, String gender,
-                                      Nationality nationality, String birthday, String name, Instant joinDate,
-                                      String profileImageUrl, Byte notificationStatus, Member.Status isApplied) {
+    private static Member createMember(Integer id, String email, String password, Member.Mbti mbti, String gender,
+                                       Nationality nationality, String birthday, String name, Instant joinDate,
+                                       String profileImageUrl, Byte notificationStatus, Member.Status isApplied) {
         return Member.builder()
                 .id(id)
                 .email(email)
@@ -32,7 +32,7 @@ public class MemberFixture {
                 .id(1)
                 .nationalityText("Korean")
                 .build();
-        return createMember(1, "test@test.com", "password", "ENFP", "F", nationality, "2000-01-01", "Test User",
+        return createMember(1, "test@test.com", "password", Member.Mbti.ENFP, "F", nationality, "2000-01-01", "Test User",
                 Instant.now(), "/default_image.jpg", (byte) 0, Member.Status.NOT_APPLIED);
     }
 
@@ -41,7 +41,7 @@ public class MemberFixture {
                 .id(1)
                 .nationalityText("Korean")
                 .build();
-        return createMember(id, email, "password", "ENFP", "F", nationality, "2000-01-01", "Test User",
+        return createMember(id, email, "password", Member.Mbti.ENFP, "F", nationality, "2000-01-01", "Test User",
                 Instant.now(), "/default_image.jpg", (byte) 0, Member.Status.NOT_APPLIED);
     }
 
@@ -50,7 +50,7 @@ public class MemberFixture {
                 .id(1)
                 .nationalityText("Korean")
                 .build();
-        return createMember(1, "test@test.com", "password", "ENFP", "F", nationality, "2000-01-01", "Test User",
+        return createMember(1, "test@test.com", "password", Member.Mbti.ENFP, "F", nationality, "2000-01-01", "Test User",
                 Instant.now(), "/default_image.jpg", (byte) 0, isApplied);
     }
 }

--- a/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/aliens/friendship/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.aliens.friendship.member.controller;
 
 import com.aliens.friendship.domain.member.controller.MemberController;
+import com.aliens.friendship.domain.member.domain.Member;
 import com.aliens.friendship.global.config.jwt.JwtAuthenticationFilter;
 import com.aliens.friendship.domain.jwt.util.JwtTokenUtil;
 import com.aliens.friendship.domain.member.controller.dto.JoinDto;
@@ -111,7 +112,7 @@ class MemberControllerTest {
         // given
         MemberInfoDto expectedMemberInfoDto = MemberInfoDto.builder()
                 .email("test@example.com")
-                .mbti("ENFP")
+                .mbti(Member.Mbti.ENFP)
                 .gender("남성")
                 .nationality("South Korea")
                 .age(24)
@@ -201,17 +202,16 @@ class MemberControllerTest {
     @DisplayName("프로필 이름과 mbti 값 변경 요청 성공")
     void ChangeProfileNameAndMbti_Success() throws Exception {
         // given
-        Map<String, String> nameAndMbti = new HashMap<>();
-        nameAndMbti.put("name", "test");
-        nameAndMbti.put("mbti", "ISFJ");
-        doNothing().when(memberService).changeProfileNameAndMbti(nameAndMbti.get("name"), nameAndMbti.get("mbti"));
+        Map<String, Member.Mbti> mbti = new HashMap<>();
+        mbti.put("mbti", Member.Mbti.ISFJ);
+        doNothing().when(memberService).changeProfileNameAndMbti(mbti.get("mbti"));
 
         // when & then
         mockMvc.perform(patch("/api/v1/member")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(nameAndMbti)))
+                        .content(new ObjectMapper().writeValueAsString(mbti)))
                 .andExpect(status().isOk());
-        verify(memberService, times(1)).changeProfileNameAndMbti(anyString(), anyString());
+        verify(memberService, times(1)).changeProfileNameAndMbti(any(Member.Mbti.class));
     }
 
     @Test

--- a/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
+++ b/src/test/java/com/aliens/friendship/member/repository/MemberRepositoryImplTest.java
@@ -44,7 +44,7 @@ class MemberRepositoryImplTest {
         //member의 정보와 mockJoinDto의 정보 일치 확인
         assertThat(member.toString()).contains(mockJoinDto.getEmail())
                 .contains(mockJoinDto.getPassword())
-                .contains(mockJoinDto.getMbti())
+                .contains(mockJoinDto.getMbti().toString())
                 .contains(mockJoinDto.getNationality().toString())
                 .contains(mockJoinDto.getBirthday())
                 .contains(mockJoinDto.getName())
@@ -67,7 +67,7 @@ class MemberRepositoryImplTest {
                 .email(email)
                 .password(password)
                 .name("Joy")
-                .mbti("ISFJ")
+                .mbti(Member.Mbti.ISFJ)
                 .gender("FEMALE")
                 .nationality(nationality)
                 .birthday("1993-12-31")

--- a/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
@@ -93,7 +93,7 @@ class MemberServiceTest {
                         .email("test@case.com")
                         .password("TestPassword")
                         .name("Ryan")
-                        .mbti("ENFJ")
+                        .mbti(Member.Mbti.ENFJ)
                         .gender("MALE")
                         .nationality(new Nationality(1, "South Korea"))
                         .birthday("1998-12-31")
@@ -344,14 +344,13 @@ class MemberServiceTest {
         // given
         JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");
         Member spyMember = createSpyMember(mockJoinDto);
-        String newName = "test";
-        String newMbti = "ISFJ";
+        Member.Mbti newMbti = Member.Mbti.ISFJ;
         when(memberRepository.findByEmail(spyMember.getEmail())).thenReturn(Optional.of(spyMember));
 
         setAuthenticationWithSpyMember(spyMember);
 
         // when
-        memberService.changeProfileNameAndMbti(newName, newMbti);
+        memberService.changeProfileNameAndMbti(newMbti);
 
         // then
         verify(memberRepository, times(1)).findByEmail(anyString());
@@ -437,7 +436,7 @@ class MemberServiceTest {
                 .email(email)
                 .password(password)
                 .name("Ryan")
-                .mbti("ENFJ")
+                .mbti(Member.Mbti.ENFJ)
                 .gender("MALE")
                 .nationality(new Nationality(1, "South Korea"))
                 .birthday("1998-12-31")

--- a/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
@@ -71,6 +71,7 @@ class MemberServiceTest {
         mockEmailAuthentication.updateStatus(EmailAuthentication.Status.VERIFIED);
         when(memberRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(Optional.empty());
         when(emailAuthenticationRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(mockEmailAuthentication);
+        doNothing().when(emailAuthenticationRepository).deleteByEmail(mockJoinDto.getEmail());
         when(profileImageService.uploadProfileImage(mockJoinDto.getProfileImage())).thenReturn("/testUrl");
 
         //when: 회원가입
@@ -101,6 +102,7 @@ class MemberServiceTest {
         mockEmailAuthentication.updateStatus(EmailAuthentication.Status.VERIFIED);
         when(memberRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(Optional.empty());
         when(emailAuthenticationRepository.findByEmail(mockJoinDto.getEmail())).thenReturn(mockEmailAuthentication);
+        doNothing().when(emailAuthenticationRepository).deleteByEmail(mockJoinDto.getEmail());
         when(profileImageService.uploadProfileImage(mockJoinDto.getProfileImage())).thenReturn(DEFAULT_PROFILE_IMAGE_PATH);
 
         //when: 회원가입

--- a/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
+++ b/src/test/java/com/aliens/friendship/member/service/MemberServiceTest.java
@@ -152,7 +152,7 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원가입 예외: 일주일 내에 탈퇴한 회원인 경우")
+    @DisplayName("회원가입 예외: 탈퇴한지 일주일이 되지 않은 이메일인 경우")
     void CreateMember_ThrowException_When_GivenWithdrawnMemberInAWeek() {
         //given: 일주일 내에 탈퇴한 회원의 이메일
         JoinDto mockJoinDto = createMockJoinDto("test@case.com", "TestPassword");


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- BACKEND-58

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 지라 이슈에 작성해 둔 부분들 모두 수정
- 이메일 인증 상태 요청 시 상태 값을 상세히 정의
  - 회원가입 후, 이메일 인증 객체가 삭제되지만 이메일 인증 후에 회원가입을 하지 않는 경우도 있어 상세하게 정의
  - JOINED: 이메일 인증 후 회원가입이 된 상태
  - EMAIL_SENDING_REQUEST_REQUIRED: 이메일 전송 요청이 필요한 상태
  - REAUTHENTICATION-REQUIRED: 이메일 인증이 되었으나, 기간 만료로 재인증이 필요한 상태 -> 이 경우, 해당 이메일 인증 객체는 필요 없으므로 삭제하도록 함.
  - AUTHENTICATED: 이메일 인증 완료
  - NOT_AUTHENTICATED: 이메일 인증 미완료

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 이메일 인증 상태 요청과 관련하여 상태 값을 상세히 정의해보았는데 의견 있으시면 남겨주시면 감사하겠습니다.!
