### PR TITLE
fix/#143 머지 후 오류 및 매칭 로직 실행 오류 해결

### DIFF
--- a/src/main/java/com/aliens/friendship/domain/auth/service/AuthService.java
+++ b/src/main/java/com/aliens/friendship/domain/auth/service/AuthService.java
@@ -105,8 +105,8 @@ public class AuthService {
         }
     }
 
-    private void checkMemberPassword(String savedPassword, String requestPassword) {
-        if (!passwordEncoder.matches(savedPassword, requestPassword))
+    private void checkMemberPassword(String requestPassword, String savedPassword) {
+        if (!passwordEncoder.matches(requestPassword, savedPassword))
             throw new MemberPasswordMisMatchException();
     }
 

--- a/src/main/java/com/aliens/friendship/domain/auth/service/AuthService.java
+++ b/src/main/java/com/aliens/friendship/domain/auth/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
                 .orElseThrow(MemberNotFoundException::new);
 
         validateMemberStatus(savedMember.getStatus());
-        checkMemberPassword(savedMember.getPassword(), request.getPassword());
+        checkMemberPassword(request.getPassword(), savedMember.getPassword());
 
         return TokenDto.of(
                 createAccessToken(request.getEmail(), savedMember.getAuthorities()).getValue(),
@@ -105,8 +105,8 @@ public class AuthService {
         }
     }
 
-    private void checkMemberPassword(String requestPassword, String savedPassword) {
-        if (!passwordEncoder.matches(requestPassword, savedPassword))
+    private void checkMemberPassword(String savedPassword, String requestPassword) {
+        if (!passwordEncoder.matches(savedPassword, requestPassword))
             throw new MemberPasswordMisMatchException();
     }
 

--- a/src/main/java/com/aliens/friendship/domain/matching/service/MatchingResultSaveService.java
+++ b/src/main/java/com/aliens/friendship/domain/matching/service/MatchingResultSaveService.java
@@ -63,6 +63,6 @@ public class MatchingResultSaveService {
     }
 
     private void deleteAllMatchings(){
-        matchingRepository.deleteAll();
+        matchingRepository.deleteAllInBatch();
     }
 }

--- a/src/main/java/com/aliens/friendship/domain/member/domain/Member.java
+++ b/src/main/java/com/aliens/friendship/domain/member/domain/Member.java
@@ -85,7 +85,7 @@ public class Member {
     @Column(name = COLUMN_WITHDRAWALDATE_NAME)
     private String withdrawalDate;
 
-    @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member", cascade = ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @Builder.Default
     private Set<Authority> authorities = new HashSet<>();
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #143 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 올바른 패스워드 임에도 비교 과정에서 불일치 오류 발생으로 passwordEncoder 매개변수 위치 수정.
- LazyInitializationException 발생으로 authorities를 즉시 로딩하도록 설정
- 기존 매칭 로직의 경우, update 시 null 값으로 인하여 오류 발생

  ![h](https://github.com/4Ailen/backend/assets/77786996/efb74571-6abc-43ac-8036-beceb5df462e)
  - 로그를 통해 matchingRepository.deleteAll(); 실행 중 오류가 발생함을 확인했습니다.
  - deleteAll의 경우 내부적으로 update 후에 삭제하는 방식으로 동작하는 경우도 있다고 하여
  - 일괄 삭제 작업을 수행하는 deleteAllInBatch로 변경 후 실행하니 정상적으로 동작하였습니다.

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 매칭 로직 수정 후 포스트맨으로 테스트 중 발견한 다른 오류들 관련해서 추가로 수정하였습니다!
