### PR TITLE
Refactor/#170 matching logic

### DIFF
--- a/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchBusiness.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchBusiness.java
@@ -141,8 +141,8 @@ public class MatchBusiness {
 
     public boolean isValidMatching(Participant participant, Participant matchedParticipant) {
         return matchedParticipant != participant &&
-                !participant.getServiceModelMatchingList().contains(matchedParticipant) &&
-                !matchedParticipant.getServiceModelMatchingList().contains(participant) &&
+                !isServiceModelMatchigListContainsParticipantId(participant.getServiceModelMatchingList(), matchedParticipant.getId()) &&
+                !isServiceModelMatchigListContainsParticipantId(matchedParticipant.getServiceModelMatchingList(), participant.getId()) &&
                 matchedParticipant.getNumberOfMatches() < maxMatches;
     }
 
@@ -150,6 +150,13 @@ public class MatchBusiness {
         return matchingParticipants.stream().allMatch(p -> p.getNumberOfMatches() >= 3);
     }
 
+    private boolean isServiceModelMatchigListContainsParticipantId(List<ServiceModelMatching> serviceModelMatchingList, Long participantId){
+        for(ServiceModelMatching serviceModelMatching : serviceModelMatchingList){
+            if(serviceModelMatching.getPartner().getId() == participantId) return true;
+        }
+
+        return false;
+    }
 }
 
 

--- a/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
@@ -1,6 +1,7 @@
 package com.aliens.friendship.domain.match.business;
 
 import com.aliens.db.applicant.entity.ApplicantEntity;
+import com.aliens.db.applicant.repository.ApplicantRepository;
 import com.aliens.db.chatting.entity.ChattingRoomEntity;
 import com.aliens.db.matching.entity.MatchingEntity;
 import com.aliens.db.member.entity.MemberEntity;
@@ -25,6 +26,7 @@ public class MatchSaveBusiness {
     private final ApplicantService applicantService;
     private final MemberService memberService;
     private final MatchService matchService;
+    private final ApplicantRepository applicantRepository;
 
     public void saveMatchingResult(List<Participant> participants) throws Exception {
         ApplicantEntity tmpApplicantEntity = applicantService.findByMemberEntity(memberService.findById(participants.get(0).getId()));
@@ -72,10 +74,21 @@ public class MatchSaveBusiness {
                     MatchingEntity matchingEntity = MatchingEntity.builder()
                             .matchingMember(matchingMemberEntity)
                             .matchedMember(matchedMemberEntity)
+                            .matchingDate(matchingDate)
                             .chattingRoomEntity(chattingRoom).build();
                     matchService.save(matchingEntity);
                 }
             }
         }
+
+        updateAllApplicantsIsMatchedToMatched();
+    }
+
+    private void updateAllApplicantsIsMatchedToMatched() {
+        List<ApplicantEntity> allParticipants = applicantService.findAllParticipants();
+        for(ApplicantEntity applicantEntity : allParticipants) {
+            applicantEntity.updateIsMatched(ApplicantEntity.Status.MATCHED);
+        }
+        applicantRepository.saveAll(allParticipants);
     }
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
@@ -4,7 +4,6 @@ import com.aliens.db.applicant.entity.ApplicantEntity;
 import com.aliens.db.chatting.entity.ChattingRoomEntity;
 import com.aliens.db.matching.entity.MatchingEntity;
 import com.aliens.db.member.entity.MemberEntity;
-import com.aliens.db.member.repository.MemberRepository;
 import com.aliens.friendship.domain.applicant.service.ApplicantService;
 import com.aliens.friendship.domain.chat.service.ChatService;
 import com.aliens.friendship.domain.match.service.MatchService;

--- a/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/match/business/MatchSaveBusiness.java
@@ -4,6 +4,7 @@ import com.aliens.db.applicant.entity.ApplicantEntity;
 import com.aliens.db.chatting.entity.ChattingRoomEntity;
 import com.aliens.db.matching.entity.MatchingEntity;
 import com.aliens.db.member.entity.MemberEntity;
+import com.aliens.db.member.repository.MemberRepository;
 import com.aliens.friendship.domain.applicant.service.ApplicantService;
 import com.aliens.friendship.domain.chat.service.ChatService;
 import com.aliens.friendship.domain.match.service.MatchService;
@@ -27,12 +28,12 @@ public class MatchSaveBusiness {
     private final MatchService matchService;
 
     public void saveMatchingResult(List<Participant> participants) throws Exception {
-        ApplicantEntity tmpApplicantEntity = applicantService.findById(participants.get(0).getId());
+        ApplicantEntity tmpApplicantEntity = applicantService.findByMemberEntity(memberService.findById(participants.get(0).getId()));
         Instant matchingDate = applicantService.getDateWillMatched(tmpApplicantEntity);
 
         for (Participant participant : participants) {
             // 신청자 엔티티
-            ApplicantEntity nowApplicantEntity = applicantService.findById(participant.getId());
+            ApplicantEntity nowApplicantEntity = applicantService.findByMemberEntity(memberService.findById(participant.getId()));
 
             // 신청자 매칭완료 상태변경
             applicantService.updateIsMatched(nowApplicantEntity);
@@ -49,8 +50,6 @@ public class MatchSaveBusiness {
 
                 // 매칭 파트너가 주인이고 매칭 주인이 파트너인 매칭 엔티티 조회
                 Optional<MatchingEntity> partnerIsMasterMatchEntity = matchService.findByMatchedMemberAndMatchingMemberReverseWithMatchingDate(matchedMemberEntity,matchingMemberEntity,matchingDate);
-                Optional<MatchingEntity> apartnerIsMasterMatchEntity = matchService.findByMatchedMemberAndMatchingMemberReverseWithMatchingDate(matchingMemberEntity,matchedMemberEntity,matchingDate);
-
 
                 //매칭 파트너가 주인인 매칭 엔티티가 있을 경우,
                 // 저장된 채팅룸으로 매칭 엔티티에 저장
@@ -80,8 +79,4 @@ public class MatchSaveBusiness {
             }
         }
     }
-
-
-
-
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/match/converter/MatchConverter.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/match/converter/MatchConverter.java
@@ -16,7 +16,7 @@ public class MatchConverter {
         List<Participant> participants = new ArrayList<>();
         for (ApplicantEntity applicantEntity : applicantEntities) {
             Participant participant = new Participant(
-                    applicantEntity.getId(),
+                    applicantEntity.getMemberEntity().getId(),
                     applicantEntity.getFirstPreferLanguage().toString(),
                     applicantEntity.getSecondPreferLanguage().toString()
             );

--- a/membership/src/test/java/com/aliens/friendship/applicant/controller/IntegrationApplicationControllerTest.java
+++ b/membership/src/test/java/com/aliens/friendship/applicant/controller/IntegrationApplicationControllerTest.java
@@ -2,6 +2,7 @@ package com.aliens.friendship.applicant.controller;
 
 import com.aliens.db.applicant.entity.ApplicantEntity;
 import com.aliens.db.member.entity.MemberEntity;
+import com.aliens.db.member.repository.MemberRepository;
 import com.aliens.friendship.domain.applicant.business.ApplicantBusiness;
 import com.aliens.friendship.domain.applicant.controller.dto.ApplicantRequestDto;
 import com.aliens.friendship.domain.applicant.service.ApplicantService;
@@ -26,6 +27,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.transaction.Transactional;
 
+import java.util.List;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -36,6 +39,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 public class IntegrationApplicationControllerTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private MockMvc mockMvc;
@@ -214,7 +220,7 @@ public class IntegrationApplicationControllerTest {
                             .selfIntroduction("Hello, I am Aden.")
                             .profileImage(createMockProfileImage())
                             .build();
-            memberEntity = memberConverter.toMemberEntityWithUser(joinRequestDto);
+            memberEntity = memberRepository.save(memberConverter.toMemberEntityWithUser(joinRequestDto));
             memberService.register(memberEntity);
 
             applicantService.register(ApplicantEntity.builder().isMatched(ApplicantEntity.Status.NOT_MATCHED)
@@ -222,11 +228,9 @@ public class IntegrationApplicationControllerTest {
                     .firstPreferLanguage(ApplicantEntity.Language.ENGLISH)
                     .secondPreferLanguage(ApplicantEntity.Language.CHINESE)
                     .build());
-
-            matchBusiness.matchingAllApplicant();
-
         }
 
+        matchBusiness.matchingAllApplicant();
 
         mockMvc.perform(
                         get(BASIC_URL+"/partners")

--- a/membership/src/test/java/com/aliens/friendship/applicant/controller/IntegrationApplicationControllerTest.java
+++ b/membership/src/test/java/com/aliens/friendship/applicant/controller/IntegrationApplicationControllerTest.java
@@ -27,8 +27,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.transaction.Transactional;
 
-import java.util.List;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/membership/src/test/java/com/aliens/friendship/emailauthentication/controller/IntegrationEmailAuthenticationControllerTest.java
+++ b/membership/src/test/java/com/aliens/friendship/emailauthentication/controller/IntegrationEmailAuthenticationControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import javax.transaction.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Slf4j
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 public class IntegrationEmailAuthenticationControllerTest {
 
     @Autowired


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #170 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- MatchBusiness
  - 매칭 중복 확인 시, 객체 비교가 정상적으로 이루어지지 않아 중복 매칭이 되는 오류가 발생하여 반복문을 통해 id 값으로 비교하도록 하였습니다.
- MatchSaveBusiness
  - applicant 테이블에 id와 member_id 속성 두개가 존재하는데, 이전 로직에서는 id 값을 사용하여 회원을 가리키지 못하는 문제를 발견하였습니다! member_id 값을 사용할 수 있도록 수정하였습니다.
  - 매칭 후, applicant의 매칭 상태를 MATCHED로 변경해주었습니다.
  - matching 엔티티 저장 시에 matchingDate 속성이 누락되어 추가해주었습니다.
- testMatchingPartners_Success
  - 테스트 코드의 경우, memberRepsitory의 save를 통해 id 값이 설정되는데, 해당 과정이 생략되어 추가하였습니다.
  - 모든 사용자가 신청 후, 매칭 로직이 돌아가도록 변경하였습니다.

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 테스트 코드 실행 후 모두 성공 확인했습니다!
![image](https://github.com/4Ailen/backend/assets/77786996/388cd485-62da-4c44-b62c-7a1e8587d2b8)

