### PR TITLE
Refactor/#212좋아요, 찜한 게시글 조회 API 합병 

### DIFF
--- a/membership/src/main/java/com/aliens/friendship/domain/article/community/controller/CommunityArticleController.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/community/controller/CommunityArticleController.java
@@ -147,15 +147,14 @@ public class CommunityArticleController {
         );
     }
 
-    @GetMapping("/api/v2/community-articles/likes")
-    public ResponseEntity<ListResult<ArticleDto>> getAllLikes(
-            @AuthenticationPrincipal UserPrincipal principal
-    ) {
-        return ResponseEntity.ok(
-                ListResult.of(
-                        "성공적으로 조회되었습니다.",
-                        communityArticleService.getAllLikes(principal)
-                )
-        );
-    }
+//    @GetMapping("/api/v2/community-articles/likes")
+//    public ResponseEntity<ListResult<ArticleDto>> getAllLikes(
+//    ) {
+//        return ResponseEntity.ok(
+//                ListResult.of(
+//                        "성공적으로 조회되었습니다.",
+//                        communityArticleService.getAllLikes()
+//                )
+//        );
+//    }
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/article/community/service/CommunityArticleService.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/community/service/CommunityArticleService.java
@@ -14,6 +14,7 @@ import com.aliens.friendship.domain.article.community.dto.CreateCommunityArticle
 import com.aliens.friendship.domain.article.community.dto.UpdateCommunityArticleRequest;
 import com.aliens.friendship.domain.article.dto.ArticleDto;
 import com.aliens.friendship.domain.fcm.service.FcmService;
+import com.aliens.friendship.domain.member.service.MemberService;
 import com.aliens.friendship.global.error.InvalidResourceOwnerException;
 import com.aliens.friendship.global.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -191,11 +192,10 @@ public class CommunityArticleService {
     }
 
     @Transactional(readOnly = true)
-    public List<ArticleDto> getAllLikes(
-            UserDetails principal
-    ) {
+    public List<ArticleDto> getAllLikes(MemberEntity loginMemberEntity) throws Exception {
+
         List<CommunityArticleEntity> communityArticles = communityArticleLikeRepository.findAllByMemberEntity(
-                        getMemberEntity(principal.getUsername())
+                        loginMemberEntity
                 )
                 .stream()
                 .map(CommunityArticleLikeEntity::getCommunityArticle)

--- a/membership/src/main/java/com/aliens/friendship/domain/article/controller/ArticleController.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/controller/ArticleController.java
@@ -1,8 +1,10 @@
 package com.aliens.friendship.domain.article.controller;
 
 import com.aliens.db.communityarticle.ArticleCategory;
+import com.aliens.friendship.domain.article.community.service.CommunityArticleService;
 import com.aliens.friendship.domain.article.dto.ArticleCategoryDto;
 import com.aliens.friendship.domain.article.dto.ArticleDto;
+import com.aliens.friendship.domain.article.market.service.MarketArticleService;
 import com.aliens.friendship.domain.article.service.ArticleService;
 import com.aliens.friendship.global.response.ListResult;
 import com.aliens.friendship.global.response.SingleResult;
@@ -103,5 +105,23 @@ public class ArticleController {
                 )
         );
     }
+
+    /**
+     * 내가 좋아요, 찜한 게시글 목록 조회
+     */
+    @ResponseBody
+    @GetMapping("/api/v2/articles/member/like")
+    public ResponseEntity<ListResult<ArticleDto>> searchArticlesByMelike(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) throws Exception {
+
+        return ResponseEntity.ok(
+                ListResult.of(
+                        "성공적으로 조회되었습니다.",
+                        articleService.searchArticlesByMyLike(pageable).getContent()
+                )
+        );
+    }
+
 
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/article/market/controller/MarketArticleController.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/market/controller/MarketArticleController.java
@@ -145,17 +145,14 @@ public class MarketArticleController {
         );
     }
 
-    @GetMapping("/bookmarks")
-    public ResponseEntity<ListResult<MarketArticleDto>> getAllBookmarks(
-            @AuthenticationPrincipal UserPrincipal principal
-    ) {
-        return ResponseEntity.ok(
-                ListResult.of(
-                        "성공적으로 조회되었습니다.",
-                        marketArticleService.getAllBookmarks(
-                                principal
-                        )
-                )
-        );
-    }
+//    @GetMapping("/bookmarks")
+//    public ResponseEntity<ListResult<MarketArticleDto>> getAllBookmarks(
+//    ) throws Exception {
+//        return ResponseEntity.ok(
+//                ListResult.of(
+//                        "성공적으로 조회되었습니다.",
+//                        marketArticleService.getAllBookmarks()
+//                )
+//        );
+//    }
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/article/market/service/MarketArticleService.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/market/service/MarketArticleService.java
@@ -9,9 +9,11 @@ import com.aliens.db.member.entity.MemberEntity;
 import com.aliens.db.member.repository.MemberRepository;
 import com.aliens.db.productimage.entity.ProductImageEntity;
 import com.aliens.db.productimage.repsitory.ProductImageRepository;
+import com.aliens.friendship.domain.article.dto.ArticleDto;
 import com.aliens.friendship.domain.article.market.dto.CreateMarketArticleRequest;
 import com.aliens.friendship.domain.article.market.dto.MarketArticleDto;
 import com.aliens.friendship.domain.article.market.dto.UpdateMarketArticleRequest;
+import com.aliens.friendship.domain.member.service.MemberService;
 import com.aliens.friendship.global.error.InvalidResourceOwnerException;
 import com.aliens.friendship.global.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,7 @@ public class MarketArticleService {
     private final MarketBookmarkRepository marketBookmarkRepository;
     private final MemberRepository memberRepository;
     private final MarketArticleCommentRepository marketArticleCommentRepository;
+    private final MemberService memberService;
 
     /**
      * 장터 게시글 검색
@@ -215,23 +218,22 @@ public class MarketArticleService {
     }
 
     @Transactional(readOnly = true)
-    public List<MarketArticleDto> getAllBookmarks(
-            UserDetails principal
-    ) {
+    public List<ArticleDto> getAllBookmarks( MemberEntity loginMemberEntity
+    )  {
         List<MarketArticleEntity> marketArticles = marketBookmarkRepository.findAllByMemberEntity(
-                        getMemberEntity(principal.getUsername())
+                        loginMemberEntity
                 )
                 .stream()
                 .map(MarketBookmarkEntity::getMarketArticle)
                 .collect(Collectors.toList());
 
-        List<MarketArticleDto> results = new ArrayList<>();
+        List<ArticleDto> results = new ArrayList<>();
         for (MarketArticleEntity marketArticle : marketArticles) {
             List<String> images = productImageRepository.findAllByMarketArticle(marketArticle)
                     .stream()
                     .map(ProductImageEntity::getImageUrl)
                     .collect(Collectors.toList());
-            results.add(MarketArticleDto.from(
+            results.add(ArticleDto.from(
                     marketArticle,
                     getMarketArticleCommentsCount(marketArticle),
                     getMarketArticleBookmarkCount(marketArticle),

--- a/membership/src/main/java/com/aliens/friendship/domain/article/service/ArticleService.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/service/ArticleService.java
@@ -235,4 +235,25 @@ public class ArticleService {
                 .distinct()
                 .collect(Collectors.toList());
     }
+
+    /**
+     * 내가 좋아요, 찜한 게시글 목록 조회
+     */
+    public Page<ArticleDto> searchArticlesByMyLike(
+            Pageable pageable
+    ) throws Exception {
+        MemberEntity loginMemberEntity = memberService.getCurrentMemberEntity();
+        List<ArticleDto> marketArticles = marketArticleService.getAllBookmarks(loginMemberEntity);
+        List<ArticleDto> communityArticles = communityArticleService.getAllLikes(loginMemberEntity);
+
+        List<ArticleDto> results = new ArrayList<>();
+        results.addAll(communityArticles);
+        results.addAll(marketArticles);
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), results.size());
+
+        return new PageImpl<>(results.subList(start, end), pageable, results.size());
+    }
+
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #212 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
-  MemberService의 getCurrentMember 메서드를 통해 현재 로그인 멤버 정보를 가져오도록 수정
-  ArticleDto로 리스트를 합쳐 전달할 수 있도록 서비스코드 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 기존의 좋아요, 찜한 게시글은 ArticleDto와 MarkerArticleDto 로 구분하여 api 두개로데이터를 전달했습니다.
그러나 ui 일관화를 위해 찜한,좋아요한 게시글을 같이 보내주기로 결정했고,
이를 위해 ArticleDto로 일관된 List를 전달하도록 수정했습니다. 
