### PR TITLE
Refactor/#233, #235 장터게시판 fetch join 코드 추가 및 게시글 생성 제한 기능 추가

### DIFF
--- a/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleCustomRepository.java
+++ b/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleCustomRepository.java
@@ -1,0 +1,9 @@
+package com.aliens.db.communityarticle.repository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface CommunityArticleCustomRepository {
+    Optional<Instant> findLatestArticleTimeByMemberId(Long memberId);
+
+}

--- a/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleRepository.java
+++ b/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleRepository.java
@@ -7,14 +7,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public interface CommunityArticleRepository
-        extends JpaRepository<CommunityArticleEntity, Long> {
+        extends JpaRepository<CommunityArticleEntity, Long>, CommunityArticleCustomRepository {
     Page<CommunityArticleEntity> findAllByCategory(ArticleCategory category, Pageable pageable);
 
     List<CommunityArticleEntity> findAllByTitleContainingOrContentContaining(String title, String content);
+
     List<CommunityArticleEntity> findAllByMember(MemberEntity member);
+
     Page<CommunityArticleEntity> findAllByCategoryAndTitleContainingOrContentContaining(ArticleCategory category, String title, String content, Pageable pageable);
+
+    Optional<Instant> findLatestArticleTimeByMemberId(Long memberId);
 
 }

--- a/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleRepositoryImpl.java
+++ b/db/src/main/java/com/aliens/db/communityarticle/repository/CommunityArticleRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.aliens.db.communityarticle.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.aliens.db.communityarticle.entity.QCommunityArticleEntity.communityArticleEntity;
+
+@RequiredArgsConstructor
+
+public class CommunityArticleRepositoryImpl implements CommunityArticleCustomRepository {
+    private final EntityManager entityManager;
+
+    @Override
+    public Optional<Instant> findLatestArticleTimeByMemberId(Long memberId) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+
+        return Optional.ofNullable(queryFactory
+                .select(communityArticleEntity.createdAt.max())
+                .from(communityArticleEntity)
+                .where(communityArticleEntity.member.id.eq(memberId))
+                .fetchOne());
+    }
+}

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleCustomRepository.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleCustomRepository.java
@@ -1,0 +1,16 @@
+package com.aliens.db.marketarticle.repository;
+
+import com.aliens.db.marketarticle.entity.MarketArticleEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface MarketArticleCustomRepository {
+
+    Page<MarketArticleEntity> findAllWithFetchJoin(Pageable pageable);
+
+    Page<MarketArticleEntity> findAllByTitleContainingOrContentContainingByFetchJoin(String title, String content, Pageable pageable);
+
+}

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleCustomRepository.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleCustomRepository.java
@@ -13,4 +13,5 @@ public interface MarketArticleCustomRepository {
 
     Page<MarketArticleEntity> findAllByTitleContainingOrContentContainingByFetchJoin(String title, String content, Pageable pageable);
 
+    Optional<Instant> findLatestArticleTimeByMemberId(Long memberId);
 }

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepository.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepository.java
@@ -6,11 +6,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 public interface MarketArticleRepository extends
-        JpaRepository<MarketArticleEntity, Long> {
+        JpaRepository<MarketArticleEntity, Long>, MarketArticleCustomRepository {
     List<MarketArticleEntity> findAllByTitleContainingOrContentContaining(String title, String content);
+
     List<MarketArticleEntity> findAllByMember(MemberEntity member);
+
     Page<MarketArticleEntity> findAllByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
+
 }

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepository.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepository.java
@@ -18,4 +18,5 @@ public interface MarketArticleRepository extends
 
     Page<MarketArticleEntity> findAllByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
 
+    Optional<Instant> findLatestArticleTimeByMemberId(Long memberId);
 }

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepositoryImpl.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.aliens.db.marketarticle.repository;
+
+import com.aliens.db.marketarticle.entity.MarketArticleEntity;
+import com.aliens.db.marketarticlecomment.entity.QMarketArticleCommentEntity;
+import com.aliens.db.marketbookmark.entity.QMarketBookmarkEntity;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.JPQLQueryFactory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.Querydsl;
+
+import javax.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static com.aliens.db.marketarticle.entity.QMarketArticleEntity.marketArticleEntity;
+import static com.aliens.db.marketarticlecomment.entity.QMarketArticleCommentEntity.*;
+import static com.aliens.db.marketbookmark.entity.QMarketBookmarkEntity.*;
+
+@RequiredArgsConstructor
+public class MarketArticleRepositoryImpl implements MarketArticleCustomRepository {
+    private final EntityManager entityManager;
+
+    @Override
+    public Page<MarketArticleEntity> findAllWithFetchJoin(Pageable pageable) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+
+        List<MarketArticleEntity> result = queryFactory
+                .selectFrom(marketArticleEntity)
+                .leftJoin(marketArticleEntity.likes, marketBookmarkEntity)
+                .leftJoin(marketArticleEntity.comments, marketArticleCommentEntity)
+                .fetchJoin()
+                .fetch();
+
+        return new PageImpl<>(result, pageable, result.size());
+    }
+
+    @Override
+    public Page<MarketArticleEntity> findAllByTitleContainingOrContentContainingByFetchJoin(String title, String content, Pageable pageable) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+
+        List<MarketArticleEntity> result = queryFactory
+                .selectFrom(marketArticleEntity)
+                .leftJoin(marketArticleEntity.likes, marketBookmarkEntity)
+                .leftJoin(marketArticleEntity.comments, marketArticleCommentEntity)
+                .fetchJoin()
+                .where(
+                        marketArticleEntity.title.containsIgnoreCase(title)
+                                .or(marketArticleEntity.content.containsIgnoreCase(content))
+                )
+                .fetch();
+
+        return new PageImpl<>(result, pageable, result.size());
+    }
+
+}

--- a/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepositoryImpl.java
+++ b/db/src/main/java/com/aliens/db/marketarticle/repository/MarketArticleRepositoryImpl.java
@@ -57,4 +57,14 @@ public class MarketArticleRepositoryImpl implements MarketArticleCustomRepositor
         return new PageImpl<>(result, pageable, result.size());
     }
 
+    @Override
+    public Optional<Instant> findLatestArticleTimeByMemberId(Long memberId) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+
+        return Optional.ofNullable(queryFactory
+                .select(marketArticleEntity.createdAt.max())
+                .from(marketArticleEntity)
+                .where(marketArticleEntity.member.id.eq(memberId))
+                .fetchOne());
+    }
 }

--- a/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleCreationNotAllowedException.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleCreationNotAllowedException.java
@@ -1,0 +1,20 @@
+package com.aliens.friendship.domain.article.exception;
+
+import com.aliens.friendship.global.error.ExceptionCode;
+import com.aliens.friendship.global.error.ResourceNotFoundException;
+
+public class ArticleCreationNotAllowedException
+        extends ResourceNotFoundException {
+
+    private ExceptionCode exceptionCode;
+
+    public ArticleCreationNotAllowedException() {
+        super(ArticleExceptionCode.ARTICLE_CREATION_NOT_ALLOWED);
+        this.exceptionCode = ArticleExceptionCode.ARTICLE_CREATION_NOT_ALLOWED;
+    }
+
+    @Override
+    public ExceptionCode getExceptionCode() {
+        return exceptionCode;
+    }
+}

--- a/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleExceptionCode.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleExceptionCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
@@ -13,7 +14,8 @@ public enum ArticleExceptionCode
         implements ExceptionCode {
 
     ARTICLE_NOT_FOUND(NOT_FOUND, "BA-C-001", "존재하지 않는 게시글입니다."),
-    ARTICLE_COMMENT_NOT_FOUND(NOT_FOUND, "BA-C-001", "존재하지 않는 게시글 댓글입니다.");
+    ARTICLE_COMMENT_NOT_FOUND(NOT_FOUND, "BA-C-001", "존재하지 않는 게시글 댓글입니다."),
+    ARTICLE_CREATION_NOT_ALLOWED(BAD_REQUEST, "BA-C-003", "게시글 생성 후 5분 후에 재생성이 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleExceptionHandler.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/exception/ArticleExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.aliens.friendship.domain.article.exception;
+
+import com.aliens.friendship.global.error.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ArticleExceptionHandler {
+
+    /**
+     * ArticleCreationNotAllowedException 핸들링
+     * Custom Exception
+     */
+    @ExceptionHandler(ArticleCreationNotAllowedException.class)
+    protected ResponseEntity<ErrorResponse> handlingArticleCreationNotAllowedException(
+            ArticleCreationNotAllowedException e
+    ) {
+        log.error("[handling ArticleCreationNotAllowedException] {}", e.getExceptionCode().getMessage());
+        return new ResponseEntity<>(
+                ErrorResponse.of(e.getExceptionCode()),
+                HttpStatus.valueOf(e.getExceptionCode().getHttpStatus().value())
+        );
+    }
+}

--- a/membership/src/main/java/com/aliens/friendship/domain/article/market/service/MarketArticleService.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/article/market/service/MarketArticleService.java
@@ -83,6 +83,36 @@ public class MarketArticleService {
                 ));
     }
 
+    @Transactional(readOnly = true)
+    public Page<MarketArticleDto> searchMarketArticlesWithFetchJoin(
+            Pageable pageable,
+            String searchKeyword
+    ) {
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            return marketArticleRepository.findAllWithFetchJoin(pageable)
+                    .map(article ->
+                            MarketArticleDto.from(
+                                    article,
+                                    article.getLikes().size(),
+                                    article.getComments().size(),
+                                    getMarketArticleImages(article)
+                            )
+                    );
+        }
+
+        return marketArticleRepository.findAllByTitleContainingOrContentContainingByFetchJoin(
+                        searchKeyword,
+                        searchKeyword,
+                        pageable
+                )
+                .map(article -> MarketArticleDto.from(
+                        article,
+                        article.getLikes().size(),
+                        article.getComments().size(),
+                        getMarketArticleImages(article)
+                ));
+    }
+
     /**
      * 장터 게시글 상세 조회
      */

--- a/membership/src/test/java/com/aliens/friendship/domain/article/market/service/MarketArticleServiceTest.java
+++ b/membership/src/test/java/com/aliens/friendship/domain/article/market/service/MarketArticleServiceTest.java
@@ -1,0 +1,46 @@
+package com.aliens.friendship.domain.article.market.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import javax.transaction.Transactional;
+
+@SpringBootTest
+class MarketArticleServiceTest {
+
+    @Autowired
+    private MarketArticleService marketArticleService;
+
+    @Test
+    @Transactional
+    public void testSearchMarketArticles() {
+        String searchKeyword = "";
+        Pageable pageable = PageRequest.of(0, 10); // Set the page and size as needed
+
+        long startTime = System.currentTimeMillis();
+        marketArticleService.searchMarketArticles(pageable, searchKeyword);
+        long endTime = System.currentTimeMillis();
+
+        System.out.println("Search time: " + (endTime - startTime) + "ms");
+
+        // Perform assertions on the result as needed
+    }
+
+    @Test
+    @Transactional
+    public void testSearchMarketArticlesWithFetchJoin() {
+        String searchKeyword = "";
+        Pageable pageable = PageRequest.of(0, 10); // Set the page and size as needed
+
+        long startTime = System.currentTimeMillis();
+        marketArticleService.searchMarketArticlesWithFetchJoin(pageable, searchKeyword);
+        long endTime = System.currentTimeMillis();
+
+        System.out.println("Search with fetch join time: " + (endTime - startTime) + "ms");
+
+        // Perform assertions on the result as needed
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- Resolved #233 
- Resolved #235

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 장터게시판 검색 기능에 fetch join 적용하는 코드 추가(기존 코드는 그대로 있고, 추가만 해뒀습니다)
- fetch join을 적용한 경우와 그렇지 않은 경우, 테스트 코드 작성을 통해 시간 비교
  - fetch join 적용한 경우
![image](https://github.com/4Ailen/backend/assets/77786996/53ddd03d-c903-4aa4-b834-a245fd5cc242)

  - fetch join 적용하지 않은 경우
![image](https://github.com/4Ailen/backend/assets/77786996/a085e973-7dcc-4be6-a861-86e7d16c62be)

- 게시글 생성 후 5분 후 재 생성 가능하도록 수정
![image](https://github.com/4Ailen/backend/assets/77786996/cd94d8ec-da32-4fe7-bb7c-db50f325ca66)


## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 게시글의 좋아요 수와 댓글 수를 가져오는 코드를 fetch join으로 바꾸니, 레코드 자체를 가져와서 카운트하는 개념이라 쿼리가 더 많이 나가서 시간이 오래 걸리는 것 같습니다! 우선, 시간적인 측면에서 이득이 없어서 코드를 수정하지 않고 추가만 해두었습니다 :)
