### PR TITLE
fix/ 신청시 중복된 신청 행위일 경우 예외를 던지도록 수정 

### DIFF
--- a/membership/src/main/java/com/aliens/friendship/domain/applicant/business/ApplicantBusiness.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/applicant/business/ApplicantBusiness.java
@@ -59,6 +59,9 @@ public class ApplicantBusiness {
         // 탈퇴하지 않은 회원 검증
         matchingInfoService.validateNotWithdraw(loginMemberEntity);
 
+        // 중복 신청 확인
+        applicantService.validateDuplicatedApplication(loginMemberEntity);
+
         //Dto -> Entity
         ApplicantEntity applicantEntity = applicantConverter.toApplicantEntity(loginMemberEntity,applicantRequestDto);
 

--- a/membership/src/main/java/com/aliens/friendship/domain/applicant/service/ApplicantService.java
+++ b/membership/src/main/java/com/aliens/friendship/domain/applicant/service/ApplicantService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.*;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -146,5 +147,14 @@ public class ApplicantService {
 
     private MemberEntity findByEmail(String email) throws Exception {
         return memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+    }
+
+    public void validateDuplicatedApplication(MemberEntity loginMemberEntity) {
+        Optional<ApplicantEntity> applicantEntity = applicantRepository.findFirstByMemberEntityOrderByCreatedAtDesc(loginMemberEntity);
+        if (applicantEntity.isPresent()) {
+            if (applicantEntity.get().getIsMatched() == ApplicantEntity.Status.NOT_MATCHED) {
+                throw new MatchingCompletedException();
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
-  Resolved #239 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
ApplicantBusiness, ApplicantService에 중복 신청 예방을 위한 메서드 ValidateDuplicatedApplication 추가 

가장 최근의 신청이 있고 만약 해당 신청의 상태가 매칭을 기다리고 있다면, 해당 상태에서 신청하는 행위는 중복 신청이기 때문에 예외를 던지도록 합니다. 
